### PR TITLE
fix: remove a filter (metric_stream_name)

### DIFF
--- a/metrics.tf
+++ b/metrics.tf
@@ -15,7 +15,6 @@ resource "observe_dataset" "metrics" {
         filter in(OBSERVATION_KIND, "http", "filedrop", "cloudwatchmetrics") and string(EXTRA["content-type"]) = "application/x-aws-cloudwatchmetrics"
         make_col data:FIELDS
 
-        filter path_exists(data, "metric_stream_name")
         make_col timestamp:timestamp_ms(int64(data.timestamp))
         set_valid_from options(max_time_diff:4h), timestamp
         make_col


### PR DESCRIPTION
## What does this PR do?

This filter (`filter path_exists(data, "metric_stream_name")`) unintentionally filters out metrics collected by CloudWatchMetrics poller.

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - let us know what you've done for testing so far. It helps the 
reviewer consider what more can be done to build confidence in the safety 
of the change. 
