### PR TITLE
fix: remove a filter (metric_stream_name)

### DIFF
--- a/metrics.tf
+++ b/metrics.tf
@@ -15,12 +15,10 @@ resource "observe_dataset" "metrics" {
         filter in(OBSERVATION_KIND, "http", "filedrop", "cloudwatchmetrics") and string(EXTRA["content-type"]) = "application/x-aws-cloudwatchmetrics"
         make_col data:FIELDS
 
-        filter path_exists(data, "metric_stream_name")
         make_col timestamp:timestamp_ms(int64(data.timestamp))
         set_valid_from options(max_time_diff:4h), timestamp
         make_col
           account_id:string(data.account_id),
-          metric_stream_name:string(data.metric_stream_name),
           region:string(data.region),
           namespace:string(data.namespace),
           metric_name:string(data.metric_name),


### PR DESCRIPTION
## What does this PR do?

`filter path_exists(data, "metric_stream_name")` unnecessarily filter out metrics collected by poller at the moment. This PR removes `filter path_exists(data, "metric_stream_name")` to support metrics collected by poller.

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - let us know what you've done for testing so far. It helps the 
reviewer consider what more can be done to build confidence in the safety 
of the change. 
