### PR TITLE
fix: OB-38940 make region of filedrop depend on cluster region

### DIFF
--- a/sources/filedrop/main.tf
+++ b/sources/filedrop/main.tf
@@ -10,6 +10,21 @@ locals {
     uri = "https://${nonsensitive(observe_datastream_token.this[0].secret)}@${trim(data.observe_ingest_info.this[0].collect_url, "https://")}/v1/http"
   }
 
+  # the frontend gets the keys, which are the cluster names from 
+  # ops/kubernetes/clusters/{CLUSTER_NAME}/vars/shared-domain.env
+  cluster_region_map = {
+    eng         = "us-west-2"
+    o2          = "us-west-2"
+    prod        = "us-west-2"
+    sandbox     = "us-west-2"
+    staging     = "us-west-2"
+    prod-cap1-2 = "us-west-2"
+    prod-ap-1   = "ap-northeast-1"
+    prod-cap1   = "us-east-1"
+    prod-eu-1   = "eu-central-1"
+    prod-cba-1  = "ap-southeast-2"
+  }
+
   post_install_vars = {
     quick_create_link              = local.quick_create_link
     name                           = local.name
@@ -51,7 +66,7 @@ resource "observe_filedrop" "aws_filedrop" {
   config {
     provider {
       aws {
-        region   = "us-west-2"
+        region   = lookup(local.cluster_region_map, var.observe_cluster, "us-west-2")
         role_arn = local.aws_role_arn
       }
     }

--- a/sources/filedrop/variables.tf
+++ b/sources/filedrop/variables.tf
@@ -12,6 +12,13 @@ variable "aws_region" {
     EOF
 }
 
+variable "observe_cluster" {
+  type        = string
+  description = <<-EOF
+      The cluster where Observe is installed.
+    EOF
+}
+
 variable "enable_config" {
   type        = bool
   description = <<-EOF


### PR DESCRIPTION
## What does this PR do?

This change makes the filedrop region match the region the cluster is installed in. The FE will provide the cluster name as an input, and there is a map that then finds the appropriate region for the filedrop.

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - let us know what you've done for testing so far. It helps the 
reviewer consider what more can be done to build confidence in the safety 
of the change. 
