### PR TITLE
fix(api-gateway): commonize resource ID across signals

### DIFF
--- a/metrics.tf
+++ b/metrics.tf
@@ -102,8 +102,7 @@ resource "observe_dataset" "metrics" {
           namespace="AWS/ApiGateway" and path_exists(dimensions, "ApiId") and path_exists(dimensions, "Stage"), concat_strings("arn:aws:apigateway:", region, "::/apis/", string(dimensions["ApiId"]), "/stages/", string(dimensions["Stage"])), 
           namespace="AWS/ApiGateway" and path_exists(dimensions, "ApiId"), concat_strings("arn:aws:apigateway:", region, "::/apis/", string(dimensions["ApiId"])),
           //ApiGateway V1
-          namespace="AWS/ApiGateway" and path_exists(dimensions, "ApiName") and path_exists(dimensions, "Stage"), concat_strings("arn:aws:apigateway:", region, "::/restapis/", string(dimensions["ApiName"]), "/stages/", string(dimensions["Stage"])),
-          namespace="AWS/ApiGateway" and path_exists(dimensions, "ApiId"), concat_strings("arn:aws:apigateway:", region, "::/restapis/", string(dimensions["ApiName"])),
+          namespace="AWS/ApiGateway" and path_exists(dimensions, "ApiName"), string(dimensions["ApiName"]),
           //ECS ContainerInsights
           namespace="ECS/ContainerInsights", string(coalesce(dimensions["TaskDefinitionFamily"], dimensions["ServiceName"], dimensions["ClusterName"])),
           namespace="AWS/PrivateLinkEndpoints" and path_exists(dimensions, "VPC Id"), string(dimensions["VPC Id"]),

--- a/resources.tf
+++ b/resources.tf
@@ -104,8 +104,15 @@ resource "observe_dataset" "resources" {
         make_col ID:case(
           Service="RDS" and ServiceSubType="DBInstance", split_part(ARN, ":db:", 2),
           Service="RDS" and ServiceSubType="DBCluster", split_part(ARN, ":cluster:", 2),
+          Service="ApiGateway" and ServiceSubType="RestApi", string(Configuration.name),
           Service="AutoScaling" and ServiceSubType="AutoScalingGroup", split_part(ARN, "autoScalingGroupName/", 2),
           true, ID)
+        
+        // ApiGateway ID is not useful for names
+        make_col Name:case(
+          Service="ApiGateway" and ServiceSubType="RestApi", concat_strings("restapis/", string(Configuration.name)),
+          true, Name
+        )
         
         make_resource options(expiry:${var.max_expiry_duration}),
           Tags,


### PR DESCRIPTION
## What does this PR do?
- ApiGatewayV1 metrics only contain  the Api and Stage names. 
- ApiGatewayV1 RestApi resource type in Config has the ApiName
- However ApiGatewayV1 Stage resource type in Config does NOT have the ApiName, meaning stage metrics cannot be linked to stages
Thus, for metrics, we choose the ApiName as the candidate for linking. Subsequently we ensure the RestApi resource type also uses the ApiName for its primary key.