### PR TITLE
feat: add quickstart instance dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ No modules.
 
 | Name | Type |
 |------|------|
+| observe_dashboard.ec2_instances | resource |
 | observe_dashboard.home | resource |
+| observe_dashboard.lambda_instances | resource |
+| observe_dashboard.rds_instances | resource |
+| observe_dashboard.sqs_services | resource |
 | observe_dataset.logs | resource |
 | observe_dataset.metrics | resource |
 | observe_dataset.resources | resource |

--- a/dashboard_ec2.tf
+++ b/dashboard_ec2.tf
@@ -1,0 +1,2656 @@
+# terraform import observe_dashboard.ec2_instances 41051012
+resource "observe_dashboard" "ec2_instances" {
+  layout = jsonencode(
+    {
+      autoPack = true
+      gridLayout = {
+        sections = [
+          {
+            card = {
+              cardType = "section"
+              closed   = false
+              title    = "Dashboard content"
+            }
+            items = [
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-wkyrd3yv"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 4
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-re6fd8fx"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 8
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-c6z3vdei"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 0
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType    = "parameter"
+                  parameterId = "groupBy"
+                }
+                layout = {
+                  h = 4
+                  resizeHandles = [
+                    "e",
+                    "w",
+                  ]
+                  w = 4
+                  x = 0
+                  y = 12
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-ujsasteu"
+                }
+                layout = {
+                  h = 23
+                  w = 12
+                  x = 0
+                  y = 16
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-ij5526eu"
+                }
+                layout = {
+                  h = 24
+                  w = 6
+                  x = 0
+                  y = 39
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-mkg9ctav"
+                }
+                layout = {
+                  h = 12
+                  w = 6
+                  x = 6
+                  y = 39
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-ys87re87"
+                }
+                layout = {
+                  h = 12
+                  w = 6
+                  x = 6
+                  y = 51
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-gfwioheu"
+                }
+                layout = {
+                  h = 12
+                  w = 6
+                  x = 6
+                  y = 63
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-n9h5zrmj"
+                }
+                layout = {
+                  h = 12
+                  w = 6
+                  x = 0
+                  y = 63
+                }
+              },
+            ]
+          },
+        ]
+      }
+      stageListLayout = {
+        isModified = false
+        parameters = [
+          {
+            autoApply = true
+            datasetId = local.aws_asset_inventory
+            defaultValue = {
+              datasetref = {
+                datasetId = local.aws_asset_inventory
+              }
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            id                    = "input-parameter-w4hr9492"
+            name                  = "AWS Asset Inventory"
+            preFilterActions = [
+              {
+                params = {
+                  columnId   = "Service"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "EC2"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+              {
+                params = {
+                  columnId   = "ServiceSubType"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "Instance"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+            ]
+            valueKind = {
+              type = "DATASETREF"
+            }
+            viewType = "input"
+          },
+          {
+            allowEmpty = false
+            defaultValue = {
+              string = "InstanceType"
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            id                    = "groupBy"
+            name                  = "Group By"
+            source                = "CustomData"
+            sourceCustomData = [
+              [
+                "VPC ID",
+                "VpcId",
+              ],
+              [
+                "Subnet ID",
+                "SubnetId",
+              ],
+              [
+                "Image ID",
+                "ImageId",
+              ],
+              [
+                "Architecture",
+                "Architecture",
+              ],
+              [
+                "Instance Type",
+                "InstanceType",
+              ],
+            ]
+            valueKind = {
+              type = "STRING"
+            }
+            viewType = "single-select"
+          },
+        ]
+        timeRange = {
+          display               = "Past 24 hours"
+          endTime               = null
+          millisFromCurrentTime = 86400000
+          originalDisplay       = "Past 24 hours"
+          startTime             = null
+          timeRangeInfo = {
+            key        = "PRESETS"
+            name       = "Presets"
+            presetType = "PAST_24_HOURS"
+          }
+        }
+      }
+    }
+  )
+  name = local.ec2_dashboard_name
+  parameters = jsonencode(
+    [
+      {
+        defaultValue = {
+          datasetref = {
+            datasetId = local.aws_asset_inventory
+          }
+        }
+        id   = "input-parameter-w4hr9492"
+        name = "AWS Asset Inventory"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "DATASETREF"
+        }
+      },
+      {
+        defaultValue = {
+          string = "InstanceType"
+        }
+        id   = "groupBy"
+        name = "Group By"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "STRING"
+        }
+      },
+    ]
+  )
+  stages = jsonencode(
+    [
+      {
+        id = "stage-ij5526eu"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/EC2/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 3020
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 0
+          inputList     = []
+          isInternal    = false
+          label         = "Max CPU Utilization"
+          managers = [
+            {
+              id         = "jb4qa5h5"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "percent (0-100)"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSEC2CPUUtilizationmax_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-j9rktt12"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "percent (0-100)"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSEC2CPUUtilizationmax_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = false
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                InstanceId = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-w4hr9492"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 2
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-tx4mkx2x"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-12T14:50:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "AutoScalingGroupName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "ImageId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceType"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/EC2/CPUUtilization.max"
+                          nameWithPath        = "AWS/EC2/CPUUtilization.max (AWS-Quickstart/Metrics)"
+                          rollup              = "max"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = "percent(0-100)"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSEC2CPUUtilizationmax_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-3pal6def"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-tx4mkx2x",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-9lazxmd9"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSEC2CPUUtilizationmax_sum:max(m(\"AWS/EC2/CPUUtilization.max\"))",
+                "aggregate A_AWSEC2CPUUtilizationmax_sum:sum(A_AWSEC2CPUUtilizationmax_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "u14qnlvd"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSEC2CPUUtilizationmax_sum:max(m("AWS/EC2/CPUUtilization.max"))
+                    aggregate A_AWSEC2CPUUtilizationmax_sum:sum(A_AWSEC2CPUUtilizationmax_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-ujsasteu"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/EC2/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 3020
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 1
+          inputList = [
+            {
+              datasetId   = local.metrics
+              id          = "query-input-t18bnewq"
+              inputName   = "AWS/EC2/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+              inputRole   = "Data"
+              isUserInput = true
+            },
+            {
+              id          = "query-input-4gzzk35z"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-w4hr9492"
+            },
+          ]
+          isInternal = false
+          label      = "Max CPU Utilization by Instance Type (Top 50)"
+          managers = [
+            {
+              id         = "9d9xpse3"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  cohort = "groupBy"
+                  colorScaleConfig = {
+                    bounds = {
+                      end   = 100
+                      start = 0
+                    }
+                    colorScaleType         = "Diverging"
+                    divergingColorScale    = "RdYlGn"
+                    divergingScaleMidpoint = 50
+                    sequentialColorScale   = "Inferno"
+                  }
+                  nodeColorConfigType = "Threshold"
+                  nodeColorField      = "cpuUtil"
+                  nodeColorMapping = [
+                    {
+                      color = "Default"
+                      key   = "__default__"
+                    },
+                    {
+                      color = ""
+                      key   = ""
+                    },
+                  ]
+                  nodeInnerTextField = "cpuUtil"
+                  nodeInnerTextUnit  = "percent (0-100)"
+                  nodeThresholds = {
+                    defaultColor  = "Blue"
+                    drawType      = "Lines"
+                    mode          = "Value"
+                    startingColor = "Default"
+                    thresholds = [
+                      {
+                        exceedsColor = "Yellow"
+                        value        = 50
+                      },
+                      {
+                        exceedsColor = "Red"
+                        value        = 80
+                      },
+                    ]
+                  }
+                  nodeTooltipFields = []
+                  type              = "hex"
+                }
+                source = {
+                  table = {
+                    type = "hex"
+                  }
+                  type = "table"
+                }
+                type = "hex"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 400
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS/EC2/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+              id            = "step-6gpbn6vz"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-2pr4dldg"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "lookup ^Resource, \"Configuration\": ^Resource.Configuration",
+                "filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align options(bins:1),",
+                "  cpuUtil:max(m(\"AWS/EC2/CPUUtilization.max\"))",
+                "aggregate",
+                "  cpuUtil:max(cpuUtil),",
+                "  group_by(^Resource...)",
+                "",
+                "topk 50, max(cpuUtil)",
+                "lookup ^Resource, \"Configuration\": ^Resource.Configuration",
+                "",
+                "make_col",
+                "  VpcId:string(Configuration.vpcId),",
+                "  SubnetId:string(Configuration.subnetId),",
+                "  ImageId:string(Configuration.imageId),",
+                "  Architecture:string(Configuration.architecture),",
+                "  InstanceType:string(Configuration.instanceType),",
+                "  State:string(Configuration.state.name)",
+                "",
+                "make_col groupBy:case(",
+                "  $groupBy=\"VpcId\", VpcId,",
+                "  $groupBy=\"SubnetId\", SubnetId,",
+                "  $groupBy=\"ImageId\", ImageId,",
+                "  $groupBy=\"Architecture\", Architecture,",
+                "  $groupBy=\"InstanceType\", InstanceType,",
+                "  $groupBy=\"State\", State,",
+                "  true, InstanceType",
+                ")",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 58.49802371541502
+            stageTab          = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    lookup ^Resource, "Configuration": ^Resource.Configuration
+                    filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align options(bins:1),
+                      cpuUtil:max(m("AWS/EC2/CPUUtilization.max"))
+                    aggregate
+                      cpuUtil:max(cpuUtil),
+                      group_by(^Resource...)
+                    
+                    topk 50, max(cpuUtil)
+                    lookup ^Resource, "Configuration": ^Resource.Configuration
+                    
+                    make_col
+                      VpcId:string(Configuration.vpcId),
+                      SubnetId:string(Configuration.subnetId),
+                      ImageId:string(Configuration.imageId),
+                      Architecture:string(Configuration.architecture),
+                      InstanceType:string(Configuration.instanceType),
+                      State:string(Configuration.state.name)
+                    
+                    make_col groupBy:case(
+                      $groupBy="VpcId", VpcId,
+                      $groupBy="SubnetId", SubnetId,
+                      $groupBy="ImageId", ImageId,
+                      $groupBy="Architecture", Architecture,
+                      $groupBy="InstanceType", InstanceType,
+                      $groupBy="State", State,
+                      true, InstanceType
+                    )
+                EOT
+      },
+      {
+        id = "stage-c6z3vdei"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "Name",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 1092
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 2
+          inputList = [
+            {
+              id          = "query-input-cq648gpe"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = false
+              parameterId = "input-parameter-w4hr9492"
+            },
+          ]
+          isInternal = false
+          managers = [
+            {
+              id         = "1ehlhrbw"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color           = "Default"
+                  colorConfigType = "Color"
+                  fieldConfig = {
+                    unit    = ""
+                    visible = false
+                  }
+                  fieldValue      = ""
+                  singleStatLabel = "Instances"
+                  thresholds      = null
+                  type            = "singlefield"
+                }
+                source = {
+                  table = {
+                    field = "A_AWSAssetInventory_count_distinct_exact"
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      fnArgs     = null
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "singlefield"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "singlevalue"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSAssetInventory_count_distinct_exact"
+              },
+            ]
+            wantBuckets = 150
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS Asset Inventory"
+              id            = "step-9vnxk5ks"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-9jyupos8"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count(), group_by()",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "500723bn"
+          }
+        }
+        params   = null
+        pipeline = "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count(), group_by()"
+      },
+      {
+        id = "stage-re6fd8fx"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 3
+          inputList     = []
+          isInternal    = false
+          label         = "Instances by Type"
+          managers = [
+            {
+              id         = "1s8hj1qo"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  innerRadius = 0.6
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "avg"
+                    }
+                    timechart = {
+                      fn         = "avg"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "A_AWSAssetInventory_count_distinct_exact"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSAssetInventory_count_distinct_exact"
+              },
+            ]
+            wantBuckets = 1
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-wux4x5if"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "avg"
+                              }
+                              timechart = {
+                                fn         = "avg"
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_AWSAssetInventory_count_distinct_exact"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        field                = "***row***"
+                        filterActions        = []
+                        groupBy = [
+                          {
+                            id   = "Configuration"
+                            path = "instanceType"
+                          },
+                        ]
+                        id = "datasetQueryExpression-0ki2am9n"
+                        inputSource = {
+                          parameterId = "input-parameter-w4hr9492"
+                        }
+                        invalidGroupBy         = []
+                        lookupActions          = []
+                        noDataVisBindingUpdate = false
+                        summaryFunction        = "count_distinct_exact"
+                        summaryMode            = "over-time"
+                        type                   = "datasetQueryExpression"
+                        valueColumnId          = "A_AWSAssetInventory_count_distinct_exact"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-n4kzwmcx"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-0ki2am9n",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-tcj4i11l"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by(Configuration.instanceType)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "wwrgxtp0"
+          }
+        }
+        params   = null
+        pipeline = "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by(Configuration.instanceType)"
+      },
+      {
+        id = "stage-wkyrd3yv"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 4
+          inputList = [
+            {
+              id          = "query-input-qfkcxgr8"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-w4hr9492"
+            },
+          ]
+          isInternal = false
+          label      = "Instances by State"
+          managers = [
+            {
+              id         = "gc9ja85o"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  innerRadius = 0.6
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "count"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSAssetInventory_count_distinct_exact"
+              },
+            ]
+            wantBuckets = 1
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS Asset Inventory"
+              id            = "step-bsi5euzj"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-z9k1wjmy"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "make_col state:string(Configuration.state.name)",
+                "timechart count:count_distinct_exact(AccountID, Region, Service, ID), group_by(state)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "gjmvidd7"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    make_col state:string(Configuration.state.name)
+                    timechart count:count_distinct_exact(AccountID, Region, Service, ID), group_by(state)
+                EOT
+      },
+      {
+        id = "stage-mkg9ctav"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/EC2/DiskReadBytessum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 5
+          inputList     = []
+          isInternal    = false
+          label         = "Disk Read Bytes Per Second"
+          managers = [
+            {
+              id         = "afc6rc3w"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "By"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSEC2DiskReadBytessum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-th39s00e"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "By"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSEC2DiskReadBytessum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              paths = {
+                                InstanceId = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-w4hr9492"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 5
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-06T17:15:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "AutoScalingGroupName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/EC2/DiskReadBytes.sum"
+                          nameWithPath        = "AWS/EC2/DiskReadBytes.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "rate"
+                          state               = "Active"
+                          suggestedBucketSize = "300000000000"
+                          type                = "gauge"
+                          unit                = "By"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSEC2DiskReadBytessum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-llx0e258"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSEC2DiskReadBytessum_sum:rate(m(\"AWS/EC2/DiskReadBytes.sum\"))",
+                "aggregate A_AWSEC2DiskReadBytessum_sum:sum(A_AWSEC2DiskReadBytessum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSEC2DiskReadBytessum_sum:rate(m("AWS/EC2/DiskReadBytes.sum"))
+                    aggregate A_AWSEC2DiskReadBytessum_sum:sum(A_AWSEC2DiskReadBytessum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-ys87re87"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/EC2/DiskWriteBytessum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 6
+          inputList     = []
+          isInternal    = false
+          label         = "Disk Write Bytes Per Second"
+          managers = [
+            {
+              id         = "zf4shdlr"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "By"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSEC2DiskWriteBytessum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-1hnf70jb"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "By"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSEC2DiskWriteBytessum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = false
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                InstanceId = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-w4hr9492"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 5
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-06T17:55:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "AutoScalingGroupName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/EC2/DiskWriteBytes.sum"
+                          nameWithPath        = "AWS/EC2/DiskWriteBytes.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "rate"
+                          state               = "Active"
+                          suggestedBucketSize = "300000000000"
+                          type                = "gauge"
+                          unit                = "By"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSEC2DiskWriteBytessum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-me7fuk0b"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSEC2DiskWriteBytessum_sum:rate(m(\"AWS/EC2/DiskWriteBytes.sum\"))",
+                "aggregate A_AWSEC2DiskWriteBytessum_sum:sum(A_AWSEC2DiskWriteBytessum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSEC2DiskWriteBytessum_sum:rate(m("AWS/EC2/DiskWriteBytes.sum"))
+                    aggregate A_AWSEC2DiskWriteBytessum_sum:sum(A_AWSEC2DiskWriteBytessum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-n9h5zrmj"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/EC2/NetworkInsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 7
+          inputList     = []
+          isInternal    = false
+          label         = "Network-In Per Second"
+          managers = [
+            {
+              id         = "rq6dv445"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "By"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSEC2NetworkInsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-8ve1caek"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "By"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSEC2NetworkInsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              paths = {
+                                InstanceId = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-w4hr9492"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 2
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-ffrhn2if"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-06T18:02:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "AutoScalingGroupName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "ImageId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceType"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/EC2/NetworkIn.sum"
+                          nameWithPath        = "AWS/EC2/NetworkIn.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "rate"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = "By"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSEC2NetworkInsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-19d5p4vq"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-ffrhn2if",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-i9nbuohv"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSEC2NetworkInsum_sum:rate(m(\"AWS/EC2/NetworkIn.sum\"))",
+                "aggregate A_AWSEC2NetworkInsum_sum:sum(A_AWSEC2NetworkInsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSEC2NetworkInsum_sum:rate(m("AWS/EC2/NetworkIn.sum"))
+                    aggregate A_AWSEC2NetworkInsum_sum:sum(A_AWSEC2NetworkInsum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-gfwioheu"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/EC2/NetworkOutsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 8
+          inputList     = []
+          isInternal    = false
+          label         = "Network-Out Per Second"
+          managers = [
+            {
+              id         = "fa4t777x"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "By"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSEC2NetworkOutsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-jgbnzceu"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "By"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSEC2NetworkOutsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = false
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                InstanceId = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-w4hr9492"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 2
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-ffrhn2if"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-06T18:02:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "AutoScalingGroupName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "ImageId"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "InstanceType"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/EC2/NetworkOut.sum"
+                          nameWithPath        = "AWS/EC2/NetworkOut.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "rate"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = "By"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSEC2NetworkOutsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-19d5p4vq"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-ffrhn2if",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-r8ky3by8"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSEC2NetworkOutsum_sum:rate(m(\"AWS/EC2/NetworkOut.sum\"))",
+                "aggregate A_AWSEC2NetworkOutsum_sum:sum(A_AWSEC2NetworkOutsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.InstanceId) or dimensions.InstanceId = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSEC2NetworkOutsum_sum:rate(m("AWS/EC2/NetworkOut.sum"))
+                    aggregate A_AWSEC2NetworkOutsum_sum:sum(A_AWSEC2NetworkOutsum_sum), group_by(^Resource...)
+                EOT
+      },
+    ]
+  )
+  workspace = local.workspace
+}
+

--- a/dashboard_lambda.tf
+++ b/dashboard_lambda.tf
@@ -1,0 +1,2804 @@
+resource "observe_dashboard" "lambda_instances" {
+  layout = jsonencode(
+    {
+      autoPack = true
+      gridLayout = {
+        sections = [
+          {
+            card = {
+              cardType = "section"
+              closed   = false
+              title    = "Dashboard content"
+            }
+            items = [
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-v7qdl4bb"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 0
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-mftjtwhp"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 4
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-08nkd6o9"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 8
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType    = "parameter"
+                  parameterId = "groupBy"
+                }
+                layout = {
+                  h = 4
+                  resizeHandles = [
+                    "e",
+                    "w",
+                  ]
+                  w = 4
+                  x = 0
+                  y = 12
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-aq4lgcxe"
+                }
+                layout = {
+                  h = 13
+                  w = 12
+                  x = 0
+                  y = 16
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-ch1s0giw"
+                }
+                layout = {
+                  h = 15
+                  w = 6
+                  x = 0
+                  y = 29
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-xdczdd5f"
+                }
+                layout = {
+                  h = 15
+                  w = 6
+                  x = 6
+                  y = 29
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-hn099j57"
+                }
+                layout = {
+                  h = 15
+                  w = 6
+                  x = 0
+                  y = 44
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-olgvcooi"
+                }
+                layout = {
+                  h = 15
+                  w = 6
+                  x = 6
+                  y = 44
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-4l182fkp"
+                }
+                layout = {
+                  h = 14
+                  w = 12
+                  x = 0
+                  y = 59
+                }
+              },
+            ]
+          },
+        ]
+      }
+      stageListLayout = {
+        isModified = false
+        parameters = [
+          {
+            autoApply = true
+            datasetId = local.aws_asset_inventory
+            defaultValue = {
+              datasetref = {
+                datasetId = local.aws_asset_inventory
+              }
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            filterActions         = []
+            id                    = "input-parameter-pi3bp6ra"
+            name                  = "AWS Asset Inventory"
+            preFilterActions = [
+              {
+                params = {
+                  columnId   = "Service"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "Lambda"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+              {
+                params = {
+                  columnId   = "ServiceSubType"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "Function"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+            ]
+            valueKind = {
+              type = "DATASETREF"
+            }
+            viewType = "input"
+          },
+          {
+            allowEmpty = false
+            defaultValue = {
+              string = "Architecture"
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            id                    = "groupBy"
+            name                  = "Group By"
+            source                = "CustomData"
+            sourceCustomData = [
+              [
+                "Architecture",
+                "Architecture",
+              ],
+              [
+                "State",
+                "State",
+              ],
+              [
+                "Memory Size",
+                "MemorySize",
+              ],
+              [
+                "Run Time",
+                "RunTime",
+              ],
+              [
+                "Storage Size",
+                "StorageSize",
+              ],
+              [
+                "Function Name",
+                "FunctionName",
+              ],
+            ]
+            valueKind = {
+              type = "STRING"
+            }
+            viewType = "single-select"
+          },
+        ]
+        timeRange = {
+          display               = "Past 24 hours"
+          endTime               = null
+          millisFromCurrentTime = 172800000
+          originalDisplay       = "Past 24 hours"
+          startTime             = null
+          timeRangeInfo = {
+            key        = "PRESETS"
+            name       = "Presets"
+            presetType = "PAST_24_HOURS"
+          }
+        }
+      }
+    }
+  )
+  name = local.lambda_dashboard_name
+  parameters = jsonencode(
+    [
+      {
+        defaultValue = {
+          datasetref = {
+            datasetId = local.aws_asset_inventory
+          }
+        }
+        id   = "input-parameter-pi3bp6ra"
+        name = "AWS Asset Inventory"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "DATASETREF"
+        }
+      },
+      {
+        defaultValue = {
+          string = "Architecture"
+        }
+        id   = "groupBy"
+        name = "Group By"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "STRING"
+        }
+      },
+    ]
+  )
+  stages = jsonencode(
+    [
+      {
+        id = "stage-v7qdl4bb"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 0
+          inputList     = []
+          isInternal    = false
+          label         = "Instances"
+          managers = [
+            {
+              id         = "2lmfvtga"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color           = "Default"
+                  colorConfigType = "Color"
+                  fieldConfig = {
+                    unit    = ""
+                    visible = false
+                  }
+                  fieldValue      = ""
+                  singleStatLabel = "Instances"
+                  thresholds      = null
+                  type            = "singlefield"
+                }
+                source = {
+                  table = {
+                    field = "A_AWSAssetInventory_count_distinct_exact"
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      fnArgs     = null
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "singlefield"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "singlevalue"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSAssetInventory_count_distinct_exact"
+              },
+            ]
+            wantBuckets = 150
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-d9dozfmj"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color           = "Default"
+                            colorConfigType = "Color"
+                            fieldConfig = {
+                              unit    = ""
+                              visible = false
+                            }
+                            fieldValue      = ""
+                            singleStatLabel = "Instances"
+                            thresholds      = null
+                            type            = "singlefield"
+                          }
+                          source = {
+                            table = {
+                              field = "A_AWSAssetInventory_count_distinct_exact"
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                fnArgs     = null
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "singlefield"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "singlevalue"
+                        }
+                        expressionIdentifier = "A"
+                        field                = "***row***"
+                        filterActions        = []
+                        groupBy              = []
+                        id                   = "datasetQueryExpression-yvunepxk"
+                        inputSource = {
+                          parameterId = "input-parameter-pi3bp6ra"
+                        }
+                        invalidGroupBy         = []
+                        lookupActions          = []
+                        noDataVisBindingUpdate = false
+                        summaryFunction        = "count_distinct_exact"
+                        summaryMode            = "over-time"
+                        type                   = "datasetQueryExpression"
+                        valueColumnId          = "A_AWSAssetInventory_count_distinct_exact"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-m7mw0t2p"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-yvunepxk",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-09sajioe"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by()",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 64.36781609195403
+            stageTab          = "vis"
+            thumbnailId       = "94jry6o8"
+          }
+        }
+        params   = null
+        pipeline = "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by()"
+      },
+      {
+        id = "stage-08nkd6o9"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride   = []
+            columnVisibility      = []
+            columnWidths = [
+              [
+                "architecture",
+                174,
+              ],
+            ]
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 2140
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 1
+          inputList = [
+            {
+              id          = "query-input-5jrmwyq3"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pi3bp6ra"
+            },
+          ]
+          isInternal = false
+          label      = "Instances by Architecture"
+          managers = [
+            {
+              id         = "ta5ce5ve"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  colorMapping = [
+                    {
+                      color = ""
+                      key   = ""
+                    },
+                  ]
+                  innerRadius = 0.6
+                  legend = {
+                    showNullAsOption = "null"
+                    type             = "list"
+                    visible          = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "avg"
+                    }
+                    timechart = {
+                      fn         = "avg"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "count"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 1000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup      = {}
+            wantBuckets = 1
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS Asset Inventory"
+              id            = "step-s52e9z68"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-pnehp5x6"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "make_col architecture:string(Configuration.architectures[0])",
+                "timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(architecture)",
+                "",
+                "",
+                "",
+                "",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 55.97701149425287
+            stageTab          = "vis"
+            thumbnailId       = "7g14tb3d"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    make_col architecture:string(Configuration.architectures[0])
+                    timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(architecture)
+                EOT
+      },
+      {
+        id = "stage-mftjtwhp"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "Name",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 2140
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 2
+          inputList = [
+            {
+              id          = "query-input-8lk7n9zp"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pi3bp6ra"
+            },
+          ]
+          isInternal = false
+          label      = "Instances by State"
+          managers = [
+            {
+              id         = "p262byp0"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  innerRadius = 0.6
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "avg"
+                    }
+                    timechart = {
+                      fn         = "avg"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "count"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 1000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup      = {}
+            wantBuckets = 1
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS Asset Inventory"
+              id            = "step-ehf6gan9"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  autoConvertType = true
+                  checkedKeys = [
+                    "state",
+                  ]
+                  columnId   = "Configuration"
+                  columnType = "object"
+                  existingColumnIds = [
+                    "Valid From",
+                    "Valid To",
+                    "Name",
+                    "AccountID",
+                    "Region",
+                    "Service",
+                    "ServiceSubType",
+                    "ID",
+                    "ARN",
+                    "Configuration",
+                    "Tags",
+                  ]
+                  expandedKeys = [
+                    "state",
+                  ]
+                  extraKeys = []
+                  typeByPath = {
+                    state = "string"
+                  }
+                }
+                summary = null
+                type    = "ExtractJSON"
+              }
+              customSummary = "string(Configuration.state)"
+              id            = "step-iocy2z6l"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "make_col state:string(Configuration.state)",
+              ]
+              type = "unknown"
+            },
+            {
+              customSummary = ""
+              id            = "step-aod8mj0g"
+              index         = 2
+              isPinned      = false
+              opal = [
+                "timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(state)",
+                "",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "ktm1byga"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    make_col state:string(Configuration.state)
+                    timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(state)
+                EOT
+      },
+      {
+        id = "stage-aq4lgcxe"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/InvocationCount"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility = [
+              [
+                "MemorySize",
+                true,
+              ],
+            ]
+            columnWidths = [
+              [
+                "metric",
+                371,
+              ],
+              [
+                "invocation_count",
+                344,
+              ],
+              [
+                "dimensions",
+                800,
+              ],
+              [
+                "_c_rank",
+                152,
+              ],
+              [
+                "Resource",
+                561,
+              ],
+            ]
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 2140
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 3
+          inputList = [
+            {
+              datasetId   = local.metrics
+              id          = "query-input-koybs932"
+              inputName   = "AWS/RDS/InvocationCount"
+              inputRole   = "Data"
+              isUserInput = true
+            },
+            {
+              id          = "query-input-p9w9feqm"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pi3bp6ra"
+            },
+          ]
+          isInternal = false
+          label      = "Total Errors (Top 25)"
+          managers = [
+            {
+              id         = "3wcyn9kd"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  cohort = "groupBy"
+                  colorScaleConfig = {
+                    bounds = {
+                      end   = 2500
+                      start = 0
+                    }
+                    colorScaleType         = "Sequential"
+                    divergingColorScale    = "RdGy"
+                    divergingScaleMidpoint = 0
+                    sequentialColorScale   = "YlOrRd"
+                  }
+                  nodeColorConfigType = "Range"
+                  nodeColorField      = "errors"
+                  nodeColorMapping = [
+                    {
+                      color = "Default"
+                      key   = "__default__"
+                    },
+                    {
+                      color = ""
+                      key   = ""
+                    },
+                  ]
+                  nodeInnerTextField = "errors"
+                  nodeInnerTextUnit  = "errors"
+                  nodeTooltipFields  = []
+                  type               = "hex"
+                }
+                source = {
+                  table = {
+                    type = "hex"
+                  }
+                  type = "table"
+                }
+                type = "hex"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup      = {}
+            wantBuckets = 400
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS/RDS/InvocationCount"
+              id            = "step-vddsah0k"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-wbzc5qp6"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.FunctionName) or dimensions.FunctionName = parse_json(\"null\")))",
+                "filter (not (is_null(dimensions.Resource)))",
+                "",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "",
+                "align options(bins:1), errors:sum(m(\"AWS/Lambda/Errors.sum\"))",
+                "aggregate errors:sum(errors), group_by(^Resource...)",
+                "",
+              ]
+              type = "unknown"
+            },
+            {
+              action = {
+                params = {
+                  columnId   = "errors"
+                  columnType = "float64"
+                  start      = 1
+                }
+                summary = null
+                type    = "FilterRange"
+              }
+              customSummary = "errors"
+              id            = "step-is61xqvw"
+              index         = 2
+              isPinned      = false
+              opal = [
+                "filter errors >= 1",
+              ]
+              type = "unknown"
+            },
+            {
+              customSummary = ""
+              id            = "step-qem9r6z5"
+              index         = 3
+              isPinned      = false
+              opal = [
+                "",
+                "topk 25, sum(errors)",
+                "lookup ^Resource, \"Configuration\": ^Resource.Configuration",
+                "",
+                "",
+                "make_col",
+                "    Architecture: string(Configuration.architectures[0]),",
+                "    State: string(Configuration.state),",
+                "    RunTime: string(Configuration.runtime),",
+                "    MemorySize: string(Configuration.memorySize),",
+                "    StorageSize: string(Configuration.ephemeralStorage.size),",
+                "    FunctionName: string(Configuration.functionName)",
+                "",
+                "make_col groupBy: case(",
+                "     $groupBy=\"Architecture\", Architecture,",
+                "     $groupBy=\"State\", State,",
+                "     $groupBy=\"RunTime\", RunTime,    ",
+                "     $groupBy=\"MemorySize\", MemorySize, ",
+                "     $groupBy=\"StorageSize\", StorageSize, ",
+                "     $groupBy=\"FunctionName\", FunctionName,",
+                "     true, Architecture",
+                "    )",
+                "",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 46.32183908045977
+            stageTab          = "vis"
+            thumbnailId       = "vvh6k7wu"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.FunctionName) or dimensions.FunctionName = parse_json("null")))
+                    filter (not (is_null(dimensions.Resource)))
+                    
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    
+                    align options(bins:1), errors:sum(m("AWS/Lambda/Errors.sum"))
+                    aggregate errors:sum(errors), group_by(^Resource...)
+                    
+                    filter errors >= 1
+                    
+                    topk 25, sum(errors)
+                    lookup ^Resource, "Configuration": ^Resource.Configuration
+                    
+                    
+                    make_col
+                        Architecture: string(Configuration.architectures[0]),
+                        State: string(Configuration.state),
+                        RunTime: string(Configuration.runtime),
+                        MemorySize: string(Configuration.memorySize),
+                        StorageSize: string(Configuration.ephemeralStorage.size),
+                        FunctionName: string(Configuration.functionName)
+                    
+                    make_col groupBy: case(
+                         $groupBy="Architecture", Architecture,
+                         $groupBy="State", State,
+                         $groupBy="RunTime", RunTime,    
+                         $groupBy="MemorySize", MemorySize, 
+                         $groupBy="StorageSize", StorageSize, 
+                         $groupBy="FunctionName", FunctionName,
+                         true, Architecture
+                        )
+                EOT
+      },
+      {
+        id = "stage-ch1s0giw"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/Lambda/Invocationssum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 4
+          inputList     = []
+          isInternal    = false
+          label         = "Invocations"
+          managers = [
+            {
+              id         = "gkqcihbu"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    unit      = ""
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSLambdaInvocationssum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-gemdukjo"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        alignDuration = {
+                          num  = 5
+                          unit = "minute"
+                        }
+                        autoFrame = true
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              unit      = ""
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSLambdaInvocationssum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                Resource = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pi3bp6ra"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 6
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-lsgwxmlz"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-14T20:57:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "FunctionName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Resource"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/Lambda/Invocations.sum"
+                          nameWithPath        = "AWS/Lambda/Invocations.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = true
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSLambdaInvocationssum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-ig6tfyb5"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-lsgwxmlz",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-ynicb1yy"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSLambdaInvocationssum_sum:sum(m(\"AWS/Lambda/Invocations.sum\"))",
+                "aggregate A_AWSLambdaInvocationssum_sum:sum(A_AWSLambdaInvocationssum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "8twsknsw"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSLambdaInvocationssum_sum:sum(m("AWS/Lambda/Invocations.sum"))
+                    aggregate A_AWSLambdaInvocationssum_sum:sum(A_AWSLambdaInvocationssum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-hn099j57"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/Lambda/Errorssum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 5
+          inputList     = []
+          isInternal    = false
+          label         = "Errors"
+          managers = [
+            {
+              id         = "g0f03paf"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    unit      = ""
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSLambdaErrorssum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-zm0vbbxq"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        alignDuration = {
+                          num  = 5
+                          unit = "minute"
+                        }
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              unit      = ""
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSLambdaErrorssum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                Resource = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pi3bp6ra"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 2
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-lsgwxmlz"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-14T20:01:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "FunctionName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Resource"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/Lambda/Errors.sum"
+                          nameWithPath        = "AWS/Lambda/Errors.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = true
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSLambdaErrorssum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-ig6tfyb5"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-lsgwxmlz",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-jbitvqli"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSLambdaErrorssum_sum:sum(m(\"AWS/Lambda/Errors.sum\"))",
+                "aggregate A_AWSLambdaErrorssum_sum:sum(A_AWSLambdaErrorssum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "fslx7mj9"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSLambdaErrorssum_sum:sum(m("AWS/Lambda/Errors.sum"))
+                    aggregate A_AWSLambdaErrorssum_sum:sum(A_AWSLambdaErrorssum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-olgvcooi"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/Lambda/Throttlessum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 6
+          inputList     = []
+          isInternal    = false
+          label         = "Throttles"
+          managers = [
+            {
+              id         = "nc33439b"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    unit      = ""
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSLambdaThrottlessum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-pz3w2dcd"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        alignDuration = {
+                          num  = 5
+                          unit = "minute"
+                        }
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              unit      = ""
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSLambdaThrottlessum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                Resource = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pi3bp6ra"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 2
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-lsgwxmlz"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-14T21:35:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "FunctionName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Resource"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/Lambda/Throttles.sum"
+                          nameWithPath        = "AWS/Lambda/Throttles.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = true
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSLambdaThrottlessum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-ig6tfyb5"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-lsgwxmlz",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-jc43gtu4"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSLambdaThrottlessum_sum:sum(m(\"AWS/Lambda/Throttles.sum\"))",
+                "aggregate A_AWSLambdaThrottlessum_sum:sum(A_AWSLambdaThrottlessum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "jeg49cy7"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSLambdaThrottlessum_sum:sum(m("AWS/Lambda/Throttles.sum"))
+                    aggregate A_AWSLambdaThrottlessum_sum:sum(A_AWSLambdaThrottlessum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-xdczdd5f"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/Lambda/Durationmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 7
+          inputList     = []
+          isInternal    = false
+          label         = "Max Duration"
+          managers = [
+            {
+              id         = "owwohjkr"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    unit      = "milliseconds"
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSLambdaDurationmax_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-eutz32jc"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              unit      = "milliseconds"
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSLambdaDurationmax_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                Resource = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pi3bp6ra"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 2
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-lsgwxmlz"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-14T01:19:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "FunctionName"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Resource"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/Lambda/Duration.max"
+                          nameWithPath        = "AWS/Lambda/Duration.max (AWS-Quickstart/Metrics)"
+                          rollup              = "max"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = "ms"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSLambdaDurationmax_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-ig6tfyb5"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-lsgwxmlz",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-bxwyr0nb"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSLambdaDurationmax_sum:max(m(\"AWS/Lambda/Duration.max\"))",
+                "aggregate A_AWSLambdaDurationmax_sum:sum(A_AWSLambdaDurationmax_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "d1xnk0il"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.Resource) or dimensions.Resource = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSLambdaDurationmax_sum:max(m("AWS/Lambda/Duration.max"))
+                    aggregate A_AWSLambdaDurationmax_sum:sum(A_AWSLambdaDurationmax_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-4l182fkp"
+        input = [
+          {
+            datasetId   = local.logs
+            datasetPath = null
+            inputName   = "AWS-Quickstart/Logs"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride   = []
+            columnVisibility = [
+              [
+                "accountId",
+                false,
+              ],
+              [
+                "region",
+                false,
+              ],
+              [
+                "service",
+                false,
+              ],
+              [
+                "resourceId",
+                false,
+              ],
+            ]
+            columnWidths = [
+              [
+                "logGroup",
+                423,
+              ],
+              [
+                "level",
+                110,
+              ],
+              [
+                "FunctionName",
+                284,
+              ],
+              [
+                "Resource",
+                514,
+              ],
+            ]
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells = {
+                message = {}
+              }
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "cell"
+            }
+            tableWidth = 2005
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 8
+          inputList = [
+            {
+              datasetId   = local.logs
+              id          = "query-input-3fme1tc1"
+              inputName   = "AWS-Quickstart/Logs"
+              inputRole   = "Data"
+              isUserInput = true
+            },
+            {
+              id          = "query-input-4tta1fg3"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pi3bp6ra"
+            },
+          ]
+          isInternal = false
+          label      = "Recent 50 Errors"
+          managers   = []
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 400
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS-Quickstart/Logs"
+              id            = "step-by4fsv6h"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-mosh3ein"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "exists accountId = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "",
+              ]
+              type = "unknown"
+            },
+            {
+              action = {
+                params = {
+                  autoConvertType = true
+                  checkedKeys = [
+                    "jsonPayload.level",
+                  ]
+                  columnId   = "message"
+                  columnType = "object"
+                  existingColumnIds = [
+                    "timestamp",
+                    "Resource",
+                    "accountId",
+                    "region",
+                    "service",
+                    "resourceId",
+                    "id",
+                    "message",
+                    "logGroup",
+                    "logStream",
+                    "messageType",
+                  ]
+                  expandedKeys = [
+                    "jsonPayload.level",
+                  ]
+                  extraKeys = []
+                  typeByPath = {
+                    "jsonPayload.level" = "string"
+                  }
+                }
+                summary = null
+                type    = "ExtractJSON"
+              }
+              customSummary = "string(message.jsonPayload.level)"
+              id            = "step-a3icsv7y"
+              index         = 2
+              isPinned      = false
+              opal = [
+                "make_col level:string(message.jsonPayload.level)",
+              ]
+              type = "unknown"
+            },
+            {
+              action = {
+                params = {
+                  autoConvertType = true
+                  checkedKeys = [
+                    "textPayload",
+                  ]
+                  columnId   = "message"
+                  columnType = "object"
+                  existingColumnIds = [
+                    "timestamp",
+                    "Resource",
+                    "accountId",
+                    "region",
+                    "service",
+                    "resourceId",
+                    "id",
+                    "message",
+                    "level",
+                    "logGroup",
+                    "logStream",
+                    "messageType",
+                  ]
+                  expandedKeys = [
+                    "textPayload",
+                  ]
+                  extraKeys = []
+                  typeByPath = {
+                    textPayload = "string"
+                  }
+                }
+                summary = null
+                type    = "ExtractJSON"
+              }
+              customSummary = "string(message.textPayload)"
+              id            = "step-mo8fy4a7"
+              index         = 3
+              isPinned      = false
+              opal = [
+                "make_col textPayload:string(message.textPayload)",
+              ]
+              type = "unknown"
+            },
+            {
+              action = {
+                params = {
+                  columnId = "textPayload"
+                  regex    = "/\\[(?P<log_level>ERROR)\\]/"
+                  sampleText = [
+                    <<-EOT
+                                            [ERROR] KeyError: 'RequestType'
+Traceback (most recent call last):
+  File "/var/task/index.py", line 17, in lambda_handler
+    if event["RequestType"] == "Create":
+                                        EOT
+                    ,
+                  ]
+                  type = "ExtractRegex"
+                }
+                summary = null
+                type    = "ExtractRegex"
+              }
+              customSummary = "textPayload regex /\\[(?P<log_level>ERROR)\\]/"
+              id            = "step-hk0ht7y6"
+              index         = 4
+              isPinned      = false
+              opal = [
+                "extract_regex textPayload, /\\[(?P<log_level>ERROR)\\]/",
+              ]
+              type = "unknown"
+            },
+            {
+              customSummary = ""
+              id            = "step-oxt54by7"
+              index         = 5
+              isPinned      = false
+              opal = [
+                "",
+                "make_col level_combined: coalesce(level, log_level, \"null\")",
+                "filter level_combined = \"ERROR\"",
+                "",
+                "set_col_visible",
+                "    textPayload: false,",
+                "    log_level: false,",
+                "    level:false,",
+                "    level_combined: false",
+                "    ",
+                "",
+              ]
+              type = "unknown"
+            },
+            {
+              action = {
+                params = {
+                  columns = [
+                    {
+                      asc = false
+                      id  = "timestamp"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "SortDescending"
+              }
+              customSummary = ""
+              id            = "step-akoh0r8f"
+              index         = 6
+              isPinned      = false
+              opal = [
+                "sort desc(timestamp)",
+              ]
+              type = "unknown"
+            },
+            {
+              customSummary = ""
+              id            = "step-6nz115ki"
+              index         = 7
+              isPinned      = false
+              opal = [
+                "limit 50",
+                "",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 51.30237825594564
+            stageTab          = "table"
+            thumbnailId       = "e38d6z92"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    exists accountId = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    
+                    make_col level:string(message.jsonPayload.level)
+                    make_col textPayload:string(message.textPayload)
+                    extract_regex textPayload, /\[(?P<log_level>ERROR)\]/
+                    
+                    make_col level_combined: coalesce(level, log_level, "null")
+                    filter level_combined = "ERROR"
+                    
+                    set_col_visible
+                        textPayload: false,
+                        log_level: false,
+                        level:false,
+                        level_combined: false
+                        
+                    
+                    sort desc(timestamp)
+                    limit 50
+                EOT
+      },
+    ]
+  )
+  workspace = local.workspace
+}
+

--- a/dashboard_rds.tf
+++ b/dashboard_rds.tf
@@ -1,0 +1,3407 @@
+resource "observe_dashboard" "rds_instances" {
+  layout = jsonencode(
+    {
+      autoPack = true
+      gridLayout = {
+        sections = [
+          {
+            card = {
+              cardType = "section"
+              closed   = false
+              title    = "Dashboard content"
+            }
+            items = [
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-zfec66yw"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 0
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-ugk7tse2"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 4
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-d36anezu"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 8
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType    = "parameter"
+                  parameterId = "groupBy"
+                }
+                layout = {
+                  h = 4
+                  resizeHandles = [
+                    "e",
+                    "w",
+                  ]
+                  w = 4
+                  x = 0
+                  y = 12
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-7t3q2n6s"
+                }
+                layout = {
+                  h = 18
+                  w = 12
+                  x = 0
+                  y = 16
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-urk9ryu6"
+                }
+                layout = {
+                  h = 22
+                  w = 6
+                  x = 0
+                  y = 34
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-yay85b89"
+                }
+                layout = {
+                  h = 11
+                  w = 6
+                  x = 6
+                  y = 34
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-smvuugxb"
+                }
+                layout = {
+                  h = 11
+                  w = 6
+                  x = 6
+                  y = 45
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-pjfpqlrv"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 0
+                  y = 56
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-8ls12a2c"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 6
+                  y = 56
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-ekgg5qje"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 0
+                  y = 74
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-vf67n4iw"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 6
+                  y = 74
+                }
+              },
+            ]
+          },
+        ]
+      }
+      stageListLayout = {
+        isModified = false
+        parameters = [
+          {
+            autoApply = true
+            datasetId = local.aws_asset_inventory
+            defaultValue = {
+              datasetref = {
+                datasetId = local.aws_asset_inventory
+              }
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            filterActions         = []
+            id                    = "input-parameter-pgp2aokw"
+            name                  = "AWS Asset Inventory"
+            preFilterActions = [
+              {
+                params = {
+                  columnId   = "Service"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "RDS"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+              {
+                params = {
+                  columnId   = "ServiceSubType"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "DBInstance"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+            ]
+            valueKind = {
+              type = "DATASETREF"
+            }
+            viewType = "input"
+          },
+          {
+            allowEmpty = false
+            defaultValue = {
+              string = "InstanceClass"
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            id                    = "groupBy"
+            name                  = "Group By"
+            source                = "CustomData"
+            sourceCustomData = [
+              [
+                "Instance Class",
+                "InstanceClass",
+              ],
+              [
+                "Status",
+                "Status",
+              ],
+              [
+                "Subnet Group Name",
+                "SubnetGroupName",
+              ],
+              [
+                "VPC ID",
+                "VpcId",
+              ],
+              [
+                "Engine",
+                "Engine",
+              ],
+              [
+                "MultiAz",
+                "MultiAz",
+              ],
+              [
+                "Cluster ID",
+                "ClusterId",
+              ],
+              [
+                "IAM Authentication Enabled",
+                "IAMAuthenticationEnabled",
+              ],
+            ]
+            valueKind = {
+              type = "STRING"
+            }
+            viewType = "single-select"
+          },
+        ]
+        selectedStageId = "stage-ugk7tse2"
+        timeRange = {
+          display               = "Past 24 hours"
+          endTime               = null
+          millisFromCurrentTime = 86400000
+          originalDisplay       = "Past 24 hours"
+          startTime             = null
+          timeRangeInfo = {
+            key        = "PRESETS"
+            name       = "Presets"
+            presetType = "PAST_24_HOURS"
+          }
+        }
+      }
+    }
+  )
+  name = local.rds_dashboard_name
+  parameters = jsonencode(
+    [
+      {
+        defaultValue = {
+          datasetref = {
+            datasetId = local.aws_asset_inventory
+          }
+        }
+        id   = "input-parameter-pgp2aokw"
+        name = "AWS Asset Inventory"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "DATASETREF"
+        }
+      },
+      {
+        defaultValue = {
+          string = "InstanceClass"
+        }
+        id   = "groupBy"
+        name = "Group By"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "STRING"
+        }
+      },
+    ]
+  )
+  stages = jsonencode(
+    [
+      {
+        id = "stage-pjfpqlrv"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 3020
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 0
+          inputList     = []
+          isInternal    = false
+          label         = "Max CPU Utilization by Instance"
+          managers = [
+            {
+              id         = "hbfrk8eo"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "% (0-100)"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSCPUUtilizationmax_sum"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-rw0ys9cc"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "% (0-100)"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSCPUUtilizationmax_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-wxzewg41"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-06T21:53:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/CPUUtilization.max"
+                          nameWithPath        = "AWS/RDS/CPUUtilization.max (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "% (0-100)"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSCPUUtilizationmax_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-b8kcpueh"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-wxzewg41",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-e97omo8f"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSRDSCPUUtilizationmax_sum:avg(m(\"AWS/RDS/CPUUtilization.max\"))",
+                "aggregate A_AWSRDSCPUUtilizationmax_sum:sum(A_AWSRDSCPUUtilizationmax_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSRDSCPUUtilizationmax_sum:avg(m("AWS/RDS/CPUUtilization.max"))
+                    aggregate A_AWSRDSCPUUtilizationmax_sum:sum(A_AWSRDSCPUUtilizationmax_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-7t3q2n6s"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 3020
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 1
+          inputList = [
+            {
+              datasetId   = local.metrics
+              id          = "query-input-koybs932"
+              inputName   = "AWS/RDS/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+              inputRole   = "Data"
+              isUserInput = true
+            },
+            {
+              id          = "query-input-p9w9feqm"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pgp2aokw"
+            },
+          ]
+          isInternal = false
+          label      = "Max. CPU Utilization (Top 50)"
+          managers = [
+            {
+              id         = "9u8zyf1i"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  cohort = "groupBy"
+                  colorScaleConfig = {
+                    bounds = {
+                      end   = 80
+                      start = 0
+                    }
+                    colorScaleType         = "Sequential"
+                    divergingColorScale    = "RdYlGn"
+                    divergingScaleMidpoint = 50
+                    sequentialColorScale   = "Oranges"
+                  }
+                  nodeColorConfigType = "Threshold"
+                  nodeColorField      = "cpu_util"
+                  nodeInnerTextField  = "cpu_util"
+                  nodeInnerTextUnit   = "% (0-100)"
+                  nodeThresholds = {
+                    defaultColor  = "Blue"
+                    drawType      = "Lines"
+                    mode          = "Value"
+                    startingColor = "Default"
+                    thresholds = [
+                      {
+                        exceedsColor = "Yellow"
+                        value        = 50
+                      },
+                      {
+                        exceedsColor = "Red"
+                        value        = 80
+                      },
+                    ]
+                  }
+                  nodeTooltipFields = []
+                  shape             = "hex"
+                  type              = "hex"
+                }
+                source = {
+                  table = {
+                    type = "hex"
+                  }
+                  type = "table"
+                }
+                type = "hex"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 400
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS/RDS/CPUUtilizationmax_from_AWS-Quickstart/Metrics"
+              id            = "step-nhw1v7ek"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-nvi8ey9f"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "",
+                "align options(bins:1), cpu_util:max(m(\"AWS/RDS/CPUUtilization.max\"))",
+                "aggregate cpu_util:max(cpu_util), group_by(^Resource...)",
+                "",
+                "topk 50, max(cpu_util)",
+                "lookup ^Resource, \"Configuration\": ^Resource.Configuration",
+                "",
+                "make_col",
+                "  InstanceClass:string(Configuration[\"dBInstanceClass\"]),",
+                "  Status:string(Configuration.dBInstanceStatus),",
+                "  SubnetGroupName:string(Configuration.dBSubnetGroup.dBSubnetGroupName),",
+                "  VpcId:string(Configuration.dBSubnetGroup.vpcId),",
+                "  Engine:concat_strings(string(Configuration.engine), \":\", string(Configuration.engineVersion)),",
+                "  MultiAz:string(Configuration.multiAZ),",
+                "  ClusterId:string(Configuration.dBClusterIdentifier),",
+                "  IAMAuthenticationEnabled:string(Configuration.iAMDatabaseAuthenticationEnabled)",
+                "",
+                "",
+                "make_col groupBy:case(",
+                "  $groupBy=\"Instance Class\", InstanceClass,",
+                "  $groupBy=\"Status\", Status,",
+                "  $groupBy=\"SubnetGroupName\", SubnetGroupName,",
+                "  $groupBy=\"VpcId\", VpcId,",
+                "  $groupBy=\"Engine\", Engine,",
+                "  $groupBy=\"MultiAz\", MultiAz,",
+                "  $groupBy=\"ClusterId\", ClusterId,",
+                "  $groupBy=\"IAMAuthenticationEnabled\", IAMAuthenticationEnabled,",
+                "  true, InstanceClass",
+                ")",
+                "  ",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 63.37285902503294
+            stageTab          = "vis"
+            thumbnailId       = "8qaxokxf"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    
+                    align options(bins:1), cpu_util:max(m("AWS/RDS/CPUUtilization.max"))
+                    aggregate cpu_util:max(cpu_util), group_by(^Resource...)
+                    
+                    topk 50, max(cpu_util)
+                    lookup ^Resource, "Configuration": ^Resource.Configuration
+                    
+                    make_col
+                      InstanceClass:string(Configuration["dBInstanceClass"]),
+                      Status:string(Configuration.dBInstanceStatus),
+                      SubnetGroupName:string(Configuration.dBSubnetGroup.dBSubnetGroupName),
+                      VpcId:string(Configuration.dBSubnetGroup.vpcId),
+                      Engine:concat_strings(string(Configuration.engine), ":", string(Configuration.engineVersion)),
+                      MultiAz:string(Configuration.multiAZ),
+                      ClusterId:string(Configuration.dBClusterIdentifier),
+                      IAMAuthenticationEnabled:string(Configuration.iAMDatabaseAuthenticationEnabled)
+                    
+                    
+                    make_col groupBy:case(
+                      $groupBy="Instance Class", InstanceClass,
+                      $groupBy="Status", Status,
+                      $groupBy="SubnetGroupName", SubnetGroupName,
+                      $groupBy="VpcId", VpcId,
+                      $groupBy="Engine", Engine,
+                      $groupBy="MultiAz", MultiAz,
+                      $groupBy="ClusterId", ClusterId,
+                      $groupBy="IAMAuthenticationEnabled", IAMAuthenticationEnabled,
+                      true, InstanceClass
+                    )
+                EOT
+      },
+      {
+        id = "stage-zfec66yw"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 2
+          inputList     = []
+          isInternal    = false
+          label         = "Instances"
+          managers = [
+            {
+              id         = "sfb1wq8c"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color           = "Default"
+                  colorConfigType = "Color"
+                  fieldConfig = {
+                    unit    = ""
+                    visible = false
+                  }
+                  fieldValue      = ""
+                  singleStatLabel = "Instances"
+                  thresholds      = null
+                  type            = "singlefield"
+                }
+                source = {
+                  table = {
+                    field = "A_AWSAssetInventory_count_distinct_exact"
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      fnArgs     = null
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "singlefield"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "singlevalue"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSAssetInventory_count_distinct_exact"
+              },
+            ]
+            wantBuckets = 150
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-k4gfmfky"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color           = "Default"
+                            colorConfigType = "Color"
+                            fieldConfig = {
+                              unit    = ""
+                              visible = false
+                            }
+                            fieldValue      = ""
+                            singleStatLabel = "Instances"
+                            thresholds      = null
+                            type            = "singlefield"
+                          }
+                          source = {
+                            table = {
+                              field = "A_AWSAssetInventory_count_distinct_exact"
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                fnArgs     = null
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "singlefield"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "singlevalue"
+                        }
+                        expressionIdentifier = "A"
+                        field                = "***row***"
+                        filterActions        = []
+                        groupBy              = []
+                        id                   = "datasetQueryExpression-yvunepxk"
+                        inputSource = {
+                          parameterId = "input-parameter-pgp2aokw"
+                        }
+                        invalidGroupBy         = []
+                        lookupActions          = []
+                        noDataVisBindingUpdate = false
+                        summaryFunction        = "count_distinct_exact"
+                        summaryMode            = "over-time"
+                        type                   = "datasetQueryExpression"
+                        valueColumnId          = "A_AWSAssetInventory_count_distinct_exact"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-m7mw0t2p"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-yvunepxk",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-1wi71huf"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by()",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by()"
+      },
+      {
+        id = "stage-ugk7tse2"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells = {
+                Configuration = {
+                  "0" = true
+                }
+              }
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "cell"
+            }
+            tableWidth = 1092
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 3
+          inputList = [
+            {
+              id          = "query-input-5jrmwyq3"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pgp2aokw"
+            },
+          ]
+          isInternal = false
+          label      = "Instances by Engine & Version"
+          managers = [
+            {
+              id         = "dzab3gkh"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  innerRadius = 0.6
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "count"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 1
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS Asset Inventory"
+              id            = "step-d78nr679"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-ilqfqyoo"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "make_col engineAndVersion:concat_strings(string(Configuration.engine), \":\", string(Configuration.engineVersion))",
+                "timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(engineAndVersion)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    make_col engineAndVersion:concat_strings(string(Configuration.engine), ":", string(Configuration.engineVersion))
+                    timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(engineAndVersion)
+                EOT
+      },
+      {
+        id = "stage-d36anezu"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "Name",
+              ],
+            ]
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 1092
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 4
+          inputList = [
+            {
+              id          = "query-input-8lk7n9zp"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-pgp2aokw"
+            },
+          ]
+          isInternal = false
+          label      = "Instances by Class"
+          managers = [
+            {
+              id         = "d8y2e4ih"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  innerRadius = 0.6
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "count"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 1
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS Asset Inventory"
+              id            = "step-00v5f84d"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-s468dxis"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "make_col dBInstanceClass:string(Configuration.dBInstanceClass)",
+                "timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(dBInstanceClass)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "bkaa43el"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    make_col dBInstanceClass:string(Configuration.dBInstanceClass)
+                    timechart options(empty_bins:true), count:count_distinct_exact(AccountID, Region, Service, ID), group_by(dBInstanceClass)
+                EOT
+      },
+      {
+        id = "stage-8ls12a2c"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/FreeableMemorymax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 5
+          inputList     = []
+          isInternal    = false
+          label         = "Max Freeable Memory"
+          managers = [
+            {
+              id         = "q09uzrzr"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "By"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSFreeableMemorymax_sum"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-1cicrpc8"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "By"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSFreeableMemorymax_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = false
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-n0ouptxk"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-12T14:09:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/FreeableMemory.max"
+                          nameWithPath        = "AWS/RDS/FreeableMemory.max (AWS-Quickstart/Metrics)"
+                          rollup              = "max"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "By"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSFreeableMemorymax_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-y9acr42b"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-n0ouptxk",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-ykjjmxjg"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSRDSFreeableMemorymax_sum:max(m(\"AWS/RDS/FreeableMemory.max\"))",
+                "aggregate A_AWSRDSFreeableMemorymax_sum:sum(A_AWSRDSFreeableMemorymax_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "qwnuuufx"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSRDSFreeableMemorymax_sum:max(m("AWS/RDS/FreeableMemory.max"))
+                    aggregate A_AWSRDSFreeableMemorymax_sum:sum(A_AWSRDSFreeableMemorymax_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-urk9ryu6"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/DatabaseConnectionssum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility = []
+            columnWidths = [
+              [
+                "Resource",
+                285,
+              ],
+            ]
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells = {
+                A_AWSRDSDatabaseConnectionssum_sum = {
+                  "2" = true
+                }
+              }
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "cell"
+            }
+            tableWidth = 2140
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 6
+          inputList     = []
+          isInternal    = false
+          label         = "Database Connections"
+          managers = [
+            {
+              id         = "r3tlrnp1"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    unit      = ""
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSDatabaseConnectionssum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-twbynuvg"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              unit      = ""
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSDatabaseConnectionssum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-n0ouptxk"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-12T22:06:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/DatabaseConnections.sum"
+                          nameWithPath        = "AWS/RDS/DatabaseConnections.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = false
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSDatabaseConnectionssum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-y9acr42b"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-n0ouptxk",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-2tprw7uf"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "align A_AWSRDSDatabaseConnectionssum_sum:avg(m(\"AWS/RDS/DatabaseConnections.sum\"))",
+                "aggregate A_AWSRDSDatabaseConnectionssum_sum:sum(A_AWSRDSDatabaseConnectionssum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 67.816091954023
+            stageTab          = "vis"
+            thumbnailId       = "3mtthxzc"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    align A_AWSRDSDatabaseConnectionssum_sum:avg(m("AWS/RDS/DatabaseConnections.sum"))
+                    aggregate A_AWSRDSDatabaseConnectionssum_sum:sum(A_AWSRDSDatabaseConnectionssum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-ekgg5qje"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/ReadThroughputmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 7
+          inputList     = []
+          isInternal    = false
+          label         = "Max Read Throughput"
+          managers = [
+            {
+              id         = "an2nd6d5"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "B/s"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSReadThroughputmax_sum"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-8acwjw4v"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "B/s"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSReadThroughputmax_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-822bzjhe"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-12T14:09:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/ReadThroughput.max"
+                          nameWithPath        = "AWS/RDS/ReadThroughput.max (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "B/s"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSReadThroughputmax_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-1tixu4qx"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-822bzjhe",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-3mfkapbv"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSRDSReadThroughputmax_sum:avg(m(\"AWS/RDS/ReadThroughput.max\"))",
+                "aggregate A_AWSRDSReadThroughputmax_sum:sum(A_AWSRDSReadThroughputmax_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "iysfijk5"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSRDSReadThroughputmax_sum:avg(m("AWS/RDS/ReadThroughput.max"))
+                    aggregate A_AWSRDSReadThroughputmax_sum:sum(A_AWSRDSReadThroughputmax_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-yay85b89"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/ReadLatencysum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 8
+          inputList     = []
+          isInternal    = false
+          label         = "Read Latency"
+          managers = [
+            {
+              id         = "w46zz91s"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "seconds"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSReadLatencysum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-ynuz72gn"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        autoFrame = true
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "seconds"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSReadLatencysum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 10
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-822bzjhe"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-12T23:53:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/ReadLatency.sum"
+                          nameWithPath        = "AWS/RDS/ReadLatency.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "s"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSReadLatencysum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-1tixu4qx"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-822bzjhe",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-xey5r6ql"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSRDSReadLatencysum_sum:avg(m(\"AWS/RDS/ReadLatency.sum\"))",
+                "aggregate A_AWSRDSReadLatencysum_sum:sum(A_AWSRDSReadLatencysum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "ues7fmw0"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSRDSReadLatencysum_sum:avg(m("AWS/RDS/ReadLatency.sum"))
+                    aggregate A_AWSRDSReadLatencysum_sum:sum(A_AWSRDSReadLatencysum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-smvuugxb"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/WriteLatencysum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 9
+          inputList     = []
+          isInternal    = false
+          label         = "Write Latency"
+          managers = [
+            {
+              id         = "uca7zt9h"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "seconds"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSWriteLatencysum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-4ssm85op"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        autoFrame = true
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "seconds"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSWriteLatencysum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-822bzjhe"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-12T23:53:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/WriteLatency.sum"
+                          nameWithPath        = "AWS/RDS/WriteLatency.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "s"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSWriteLatencysum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-1tixu4qx"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-822bzjhe",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-5dnoj6as"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSRDSWriteLatencysum_sum:avg(m(\"AWS/RDS/WriteLatency.sum\"))",
+                "aggregate A_AWSRDSWriteLatencysum_sum:sum(A_AWSRDSWriteLatencysum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "ak3xdi99"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSRDSWriteLatencysum_sum:avg(m("AWS/RDS/WriteLatency.sum"))
+                    aggregate A_AWSRDSWriteLatencysum_sum:sum(A_AWSRDSWriteLatencysum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-vf67n4iw"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/RDS/WriteThroughputmax_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 10
+          inputList     = []
+          isInternal    = false
+          label         = "Max Write Throughput"
+          managers = [
+            {
+              id         = "xj7pb3zg"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    type    = "list"
+                    visible = true
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "B/s"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSRDSWriteThroughputmax_sum"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 250
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-h65boahz"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              type    = "list"
+                              visible = true
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "B/s"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSRDSWriteThroughputmax_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              paths = {
+                                DBInstanceIdentifier = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId   = "Resource"
+                              columnType = "link"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset    = local.aws_asset_inventory
+                                targetStageLabel = ""
+                                type             = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-pgp2aokw"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-dba0enws"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-09-12T14:09:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBInstanceIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DBClusterIdentifier"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "DatabaseClass"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "Role"
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "EngineName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/RDS/WriteThroughput.max"
+                          nameWithPath        = "AWS/RDS/WriteThroughput.max (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "B/s"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSRDSWriteThroughputmax_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-70wyyqyp"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-dba0enws",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-bfi0v0y6"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSRDSWriteThroughputmax_sum:avg(m(\"AWS/RDS/WriteThroughput.max\"))",
+                "aggregate A_AWSRDSWriteThroughputmax_sum:sum(A_AWSRDSWriteThroughputmax_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "adlfmgia"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.DBInstanceIdentifier) or dimensions.DBInstanceIdentifier = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSRDSWriteThroughputmax_sum:avg(m("AWS/RDS/WriteThroughput.max"))
+                    aggregate A_AWSRDSWriteThroughputmax_sum:sum(A_AWSRDSWriteThroughputmax_sum), group_by(^Resource...)
+                EOT
+      },
+    ]
+  )
+  workspace = local.workspace
+}
+

--- a/dashboard_sqs.tf
+++ b/dashboard_sqs.tf
@@ -1,0 +1,3819 @@
+# terraform import observe_dashboard.sqs_services 41054051
+resource "observe_dashboard" "sqs_services" {
+  layout = jsonencode(
+    {
+      autoPack = true
+      gridLayout = {
+        sections = [
+          {
+            card = {
+              cardType = "section"
+              closed   = false
+              title    = "Dashboard content"
+            }
+            items = [
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-vyy6zut2"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 0
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-drc4l0l9"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 4
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-gq7q2d8q"
+                }
+                layout = {
+                  h = 12
+                  w = 4
+                  x = 8
+                  y = 0
+                }
+              },
+              {
+                card = {
+                  cardType    = "parameter"
+                  parameterId = "groupBy"
+                }
+                layout = {
+                  h = 4
+                  resizeHandles = [
+                    "e",
+                    "w",
+                  ]
+                  w = 4
+                  x = 0
+                  y = 12
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-vvnpra3a"
+                }
+                layout = {
+                  h = 25
+                  w = 12
+                  x = 0
+                  y = 16
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-z82tspqu"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 0
+                  y = 41
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-dcwhlhvy"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 6
+                  y = 41
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-txhxj2kv"
+                }
+                layout = {
+                  h = 17
+                  w = 6
+                  x = 0
+                  y = 59
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-bfrw9s43"
+                }
+                layout = {
+                  h = 17
+                  w = 6
+                  x = 6
+                  y = 59
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-yk8ci7ll"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 0
+                  y = 76
+                }
+              },
+              {
+                card = {
+                  cardType = "stage"
+                  stageId  = "stage-wwsekg1r"
+                }
+                layout = {
+                  h = 18
+                  w = 6
+                  x = 6
+                  y = 76
+                }
+              },
+            ]
+          },
+        ]
+      }
+      stageListLayout = {
+        isModified = false
+        parameters = [
+          {
+            autoApply = true
+            datasetId = local.aws_asset_inventory
+            defaultValue = {
+              datasetref = {
+                datasetId = local.aws_asset_inventory
+              }
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            filterActions         = []
+            id                    = "input-parameter-oqnf8rxx"
+            name                  = "AWS Asset Inventory"
+            preFilterActions = [
+              {
+                params = {
+                  columnId   = "Service"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "SQS"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+              {
+                params = {
+                  columnId   = "ServiceSubType"
+                  columnType = "string"
+                  filterVerb = "ever"
+                  values = [
+                    {
+                      isExcluding = false
+                      value       = "Queue"
+                    },
+                  ]
+                }
+                summary = null
+                type    = "FilterValues"
+              },
+            ]
+            valueKind = {
+              type = "DATASETREF"
+            }
+            viewType = "input"
+          },
+          {
+            allowEmpty = false
+            defaultValue = {
+              string = "Account"
+            }
+            emptyValueEncoding    = "null"
+            emptyValueLabelOption = "null"
+            id                    = "groupBy"
+            name                  = "Group By"
+            source                = "CustomData"
+            sourceCustomData = [
+              [
+                "Account",
+                "Account",
+              ],
+              [
+                "Region",
+                "Region",
+              ],
+              [
+                "Message Retention Period",
+                "MessageRetentionPeriod",
+              ],
+              [
+                "Maximum Message Size",
+                "MaximumMessageSize",
+              ],
+            ]
+            valueKind = {
+              type = "STRING"
+            }
+            viewType = "single-select"
+          },
+        ]
+        timeRange = {
+          display               = "Past 24 hours"
+          endTime               = null
+          millisFromCurrentTime = 86400000
+          originalDisplay       = "Past 24 hours"
+          startTime             = null
+          timeRangeInfo = {
+            key        = "PRESETS"
+            name       = "Presets"
+            presetType = "PAST_24_HOURS"
+          }
+        }
+      }
+    }
+  )
+  name = local.sqs_dashboard_name
+  parameters = jsonencode(
+    [
+      {
+        defaultValue = {
+          datasetref = {
+            datasetId = local.aws_asset_inventory
+          }
+        }
+        id   = "input-parameter-oqnf8rxx"
+        name = "AWS Asset Inventory"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "DATASETREF"
+        }
+      },
+      {
+        defaultValue = {
+          string = "Account"
+        }
+        id   = "groupBy"
+        name = "Group By"
+        valueKind = {
+          arrayItemType   = null
+          keyForDatasetId = null
+          type            = "STRING"
+        }
+      },
+    ]
+  )
+  stages = jsonencode(
+    [
+      {
+        id = "stage-vyy6zut2"
+        input = [
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 0
+          inputList     = []
+          isInternal    = false
+          label         = "Queues"
+          managers = [
+            {
+              id         = "7tireaec"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  color           = "Default"
+                  colorConfigType = "Color"
+                  fieldConfig = {
+                    unit    = ""
+                    visible = false
+                  }
+                  fieldValue      = ""
+                  singleStatLabel = "Queues"
+                  thresholds      = null
+                  type            = "singlefield"
+                }
+                source = {
+                  table = {
+                    field = "A_AWSAssetInventory_count_distinct_exact"
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      fnArgs     = null
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "singlefield"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "singlevalue"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSAssetInventory_count_distinct_exact"
+              },
+            ]
+            wantBuckets = 150
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-hsqmsqx6"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            color           = "Default"
+                            colorConfigType = "Color"
+                            fieldConfig = {
+                              unit    = ""
+                              visible = false
+                            }
+                            fieldValue      = ""
+                            singleStatLabel = "Queues"
+                            thresholds      = null
+                            type            = "singlefield"
+                          }
+                          source = {
+                            table = {
+                              field = "A_AWSAssetInventory_count_distinct_exact"
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                fnArgs     = null
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "singlefield"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "singlevalue"
+                        }
+                        expressionIdentifier = "A"
+                        field                = "***row***"
+                        filterActions        = []
+                        groupBy              = []
+                        id                   = "datasetQueryExpression-yvunepxk"
+                        inputSource = {
+                          parameterId = "input-parameter-oqnf8rxx"
+                        }
+                        invalidGroupBy         = []
+                        lookupActions          = []
+                        noDataVisBindingUpdate = false
+                        summaryFunction        = "count_distinct_exact"
+                        summaryMode            = "over-time"
+                        type                   = "datasetQueryExpression"
+                        valueColumnId          = "A_AWSAssetInventory_count_distinct_exact"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-m7mw0t2p"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "datasetQueryExpression-yvunepxk",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-n9ypn5uu"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by()",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 64.36781609195403
+            stageTab          = "vis"
+            thumbnailId       = "6btgxxvi"
+          }
+        }
+        params   = null
+        pipeline = "timechart options(empty_bins:true), A_AWSAssetInventory_count_distinct_exact:count_distinct_exact(AccountID, Region, Service, ID), group_by()"
+      },
+      {
+        id = "stage-drc4l0l9"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesSentsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 1
+          inputList     = []
+          isInternal    = false
+          label         = "Queues by Messages Sent"
+          managers = [
+            {
+              id         = "361iycka"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  innerRadius = 0.6
+                  legend = {
+                    placement = "right"
+                    type      = "list"
+                    visible   = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "A_AWSSQSNumberOfMessagesSentsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 1
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-xtqfisdm"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_AWSSQSNumberOfMessagesSentsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T19:23:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/NumberOfMessagesSent.sum"
+                          nameWithPath        = "AWS/SQS/NumberOfMessagesSent.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "single"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSNumberOfMessagesSentsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-ktk6b4u0"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align options(bins: 1), A_AWSSQSNumberOfMessagesSentsum_sum:sum(m(\"AWS/SQS/NumberOfMessagesSent.sum\"))",
+                "aggregate A_AWSSQSNumberOfMessagesSentsum_sum:sum(A_AWSSQSNumberOfMessagesSentsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "0bzmxdjn"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align options(bins: 1), A_AWSSQSNumberOfMessagesSentsum_sum:sum(m("AWS/SQS/NumberOfMessagesSent.sum"))
+                    aggregate A_AWSSQSNumberOfMessagesSentsum_sum:sum(A_AWSSQSNumberOfMessagesSentsum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-gq7q2d8q"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 2
+          inputList     = []
+          isInternal    = false
+          label         = "Queues by Messages Received"
+          managers = [
+            {
+              id         = "51gjshvl"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  colorMapping = [
+                    {
+                      color = ""
+                      key   = ""
+                    },
+                  ]
+                  innerRadius = 0.6
+                  legend = {
+                    placement = "right"
+                    type      = "list"
+                    visible   = true
+                  }
+                  type = "arc"
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "SINGLE"
+                    }
+                    transformType = "none"
+                    type          = "keyvalue"
+                    valueField    = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "circular"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+              },
+            ]
+            wantBuckets = 1
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-l3xespn1"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            colorMapping = [
+                              {
+                                color = ""
+                                key   = ""
+                              },
+                            ]
+                            innerRadius = 0.6
+                            legend = {
+                              placement = "right"
+                              type      = "list"
+                              visible   = true
+                            }
+                            type = "arc"
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "SINGLE"
+                              }
+                              transformType = "none"
+                              type          = "keyvalue"
+                              valueField    = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "circular"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T19:23:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/NumberOfMessagesReceived.sum"
+                          nameWithPath        = "AWS/SQS/NumberOfMessagesReceived.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "single"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-3dyvn3wt"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align options(bins: 1), A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(m(\"AWS/SQS/NumberOfMessagesReceived.sum\"))",
+                "aggregate A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(A_AWSSQSNumberOfMessagesReceivedsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "2z6yd63s"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align options(bins: 1), A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(m("AWS/SQS/NumberOfMessagesReceived.sum"))
+                    aggregate A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(A_AWSSQSNumberOfMessagesReceivedsum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-vvnpra3a"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility = []
+            columnWidths = [
+              [
+                "dimensions",
+                474,
+              ],
+              [
+                "ApproximateAgeOfOldestMessage",
+                298,
+              ],
+              [
+                "MessageRetentionPeriod",
+                197,
+              ],
+              [
+                "Configuration",
+                484,
+              ],
+              [
+                "MaximumMessageSize",
+                222,
+              ],
+              [
+                "Resource",
+                416,
+              ],
+              [
+                "Resource_",
+                339,
+              ],
+            ]
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells = {
+                Configuration = {
+                  "0" = true
+                }
+              }
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "cell"
+            }
+            tableWidth = 1867
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 3
+          inputList = [
+            {
+              datasetId   = local.metrics
+              id          = "query-input-upnydhax"
+              inputName   = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+              inputRole   = "Data"
+              isUserInput = false
+            },
+            {
+              id          = "query-input-ztwq41pn"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-oqnf8rxx"
+            },
+          ]
+          isInternal = false
+          label      = "Max Age of Oldest Message by Instance (Top 50)"
+          managers = [
+            {
+              id         = "rgo0v0mo"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  cohort = "groupBy"
+                  colorScaleConfig = {
+                    bounds = {
+                      end   = 5000
+                      start = 1
+                    }
+                    colorScaleType         = "Sequential"
+                    divergingColorScale    = "RdYlGn"
+                    divergingScaleMidpoint = 0
+                    sequentialColorScale   = "YlOrBr"
+                  }
+                  nodeColorConfigType = "Range"
+                  nodeColorField      = "ApproximateAgeOfOldestMessage"
+                  nodeColorMapping = [
+                    {
+                      color = "Default"
+                      key   = "__default__"
+                    },
+                    {
+                      color = ""
+                      key   = ""
+                    },
+                  ]
+                  nodeInnerTextField = "ApproximateAgeOfOldestMessage"
+                  nodeInnerTextUnit  = "seconds"
+                  nodeTooltipFields  = []
+                  type               = "hex"
+                }
+                source = {
+                  table = {
+                    type = "hex"
+                  }
+                  type = "table"
+                }
+                type = "hex"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup      = {}
+            wantBuckets = 400
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+              id            = "step-ectq0d9o"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-pihyblzi"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "",
+                "align options(bins:1), ApproximateAgeOfOldestMessage:max(m(\"AWS/SQS/ApproximateAgeOfOldestMessage.max\"))",
+                "aggregate ApproximateAgeOfOldestMessage:sum(ApproximateAgeOfOldestMessage), group_by(^Resource...)",
+                "",
+                "filter ApproximateAgeOfOldestMessage >= 1",
+                "",
+                "topk 50, sum(ApproximateAgeOfOldestMessage)",
+                "lookup ^Resource, \"Configuration\": ^Resource.Configuration",
+                "",
+                "",
+                "make_col ",
+                "    MessageRetentionPeriod:duration_sec(Configuration.MessageRetentionPeriod),",
+                "    MaximumMessageSize:string(Configuration.MaximumMessageSize) + \" bytes\"",
+                "",
+                "make_col groupBy: case(",
+                "     $groupBy=\"MessageRetentionPeriod\",  string(MessageRetentionPeriod),",
+                "     $groupBy=\"MaximumMessageSize\", MaximumMessageSize,",
+                "     $groupBy=\"Account\", account_id, ",
+                "     $groupBy=\"Region\", region, ",
+                "     true, label(^Resource)",
+                "    )",
+                "",
+                "",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 38.735632183908045
+            stageTab          = "vis"
+            thumbnailId       = "6uv7x0mj"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    
+                    align options(bins:1), ApproximateAgeOfOldestMessage:max(m("AWS/SQS/ApproximateAgeOfOldestMessage.max"))
+                    aggregate ApproximateAgeOfOldestMessage:sum(ApproximateAgeOfOldestMessage), group_by(^Resource...)
+                    
+                    filter ApproximateAgeOfOldestMessage >= 1
+                    
+                    topk 50, sum(ApproximateAgeOfOldestMessage)
+                    lookup ^Resource, "Configuration": ^Resource.Configuration
+                    
+                    
+                    make_col 
+                        MessageRetentionPeriod:duration_sec(Configuration.MessageRetentionPeriod),
+                        MaximumMessageSize:string(Configuration.MaximumMessageSize) + " bytes"
+                    
+                    make_col groupBy: case(
+                         $groupBy="MessageRetentionPeriod",  string(MessageRetentionPeriod),
+                         $groupBy="MaximumMessageSize", MaximumMessageSize,
+                         $groupBy="Account", account_id, 
+                         $groupBy="Region", region, 
+                         true, label(^Resource)
+                        )
+                EOT
+      },
+      {
+        id = "stage-calkwa27"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation = []
+            columnOrderOverride = [
+              [
+                0,
+                "valid_from",
+              ],
+              [
+                1,
+                "valid_to",
+              ],
+            ]
+            columnVisibility = []
+            columnWidths = [
+              [
+                "dimensions",
+                474,
+              ],
+              [
+                "ApproximateAgeOfOldestMessage",
+                225,
+              ],
+            ]
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 574
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 4
+          inputList = [
+            {
+              datasetId   = local.metrics
+              id          = "query-input-upnydhax"
+              inputName   = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+              inputRole   = "Data"
+              isUserInput = false
+            },
+            {
+              id          = "query-input-ztwq41pn"
+              inputName   = "AWS Asset Inventory"
+              inputRole   = "Data"
+              isUserInput = true
+              parameterId = "input-parameter-oqnf8rxx"
+            },
+          ]
+          isInternal = false
+          label      = "Sent Message Size"
+          managers   = []
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            rollup = {}
+          }
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+              id            = "step-auz08qxs"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              customSummary = ""
+              id            = "step-ia3t2nj3"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "",
+                "align options(bins:1), SentMessageSize:avg(m(\"AWS/SQS/SentMessageSize.sum\"))",
+                "// aggregate SentMessageSize:sum(SentMessageSize), group_by(^Resource...)",
+                "",
+                "// filter SentMessageSize >= 1",
+                "",
+                "// topk 25, sum(SentMessageSize)",
+                "// lookup ^Resource, \"Configuration\": ^Resource.Configuration",
+                "",
+                "",
+                "// make_col",
+                "//     Architecture: string(Configuration.architectures[0]),",
+                "//     State: string(Configuration.state),",
+                "//     RunTime: string(Configuration.runtime),",
+                "//     MemorySize: string(Configuration.memorySize),",
+                "//     StorageSize: string(Configuration.ephemeralStorage.size),",
+                "//     FunctionName: string(Configuration.functionName)",
+                "",
+                "// make_col groupBy: case(",
+                "//      $groupBy=\"Architecture\", Architecture,",
+                "//      $groupBy=\"State\", State,",
+                "//      $groupBy=\"RunTime\", RunTime,    ",
+                "//      $groupBy=\"MemorySize\", MemorySize, ",
+                "//      $groupBy=\"StorageSize\", StorageSize, ",
+                "//      $groupBy=\"FunctionName\", FunctionName,",
+                "//      true, Architecture",
+                "//     )",
+                "",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "OPAL"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler     = true
+            stageOutputHeight = 53.45005149330587
+            stageTab          = "table"
+            thumbnailId       = "vbh46jmu"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    
+                    align options(bins:1), SentMessageSize:avg(m("AWS/SQS/SentMessageSize.sum"))
+                    // aggregate SentMessageSize:sum(SentMessageSize), group_by(^Resource...)
+                    
+                    // filter SentMessageSize >= 1
+                    
+                    // topk 25, sum(SentMessageSize)
+                    // lookup ^Resource, "Configuration": ^Resource.Configuration
+                    
+                    
+                    // make_col
+                    //     Architecture: string(Configuration.architectures[0]),
+                    //     State: string(Configuration.state),
+                    //     RunTime: string(Configuration.runtime),
+                    //     MemorySize: string(Configuration.memorySize),
+                    //     StorageSize: string(Configuration.ephemeralStorage.size),
+                    //     FunctionName: string(Configuration.functionName)
+                    
+                    // make_col groupBy: case(
+                    //      $groupBy="Architecture", Architecture,
+                    //      $groupBy="State", State,
+                    //      $groupBy="RunTime", RunTime,    
+                    //      $groupBy="MemorySize", MemorySize, 
+                    //      $groupBy="StorageSize", StorageSize, 
+                    //      $groupBy="FunctionName", FunctionName,
+                    //      true, Architecture
+                    //     )
+                EOT
+      },
+      {
+        id = "stage-z82tspqu"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesSentsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 5
+          inputList     = []
+          isInternal    = false
+          label         = "Number of Messages Sent"
+          managers = [
+            {
+              id         = "ozgxk06z"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  annotations   = []
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    placement = "bottom"
+                    type      = "list"
+                    visible   = true
+                  }
+                  thresholds = {
+                    startingColor = "Default"
+                    thresholds    = []
+                    visible       = false
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSSQSNumberOfMessagesSentsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 250
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-msy1al49"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            annotations   = []
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              placement = "bottom"
+                              type      = "list"
+                              visible   = true
+                            }
+                            thresholds = {
+                              startingColor = "Default"
+                              thresholds    = []
+                              visible       = false
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSSQSNumberOfMessagesSentsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T19:23:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/NumberOfMessagesSent.sum"
+                          nameWithPath        = "AWS/SQS/NumberOfMessagesSent.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSNumberOfMessagesSentsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-lfkedtik"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSSQSNumberOfMessagesSentsum_sum:sum(m(\"AWS/SQS/NumberOfMessagesSent.sum\"))",
+                "aggregate A_AWSSQSNumberOfMessagesSentsum_sum:sum(A_AWSSQSNumberOfMessagesSentsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "t8gdh9r2"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSSQSNumberOfMessagesSentsum_sum:sum(m("AWS/SQS/NumberOfMessagesSent.sum"))
+                    aggregate A_AWSSQSNumberOfMessagesSentsum_sum:sum(A_AWSSQSNumberOfMessagesSentsum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-yk8ci7ll"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/ApproximateAgeOfOldestMessagesum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 6
+          inputList     = []
+          isInternal    = false
+          label         = "Approximate Age of Oldest Message"
+          managers = [
+            {
+              id         = "67kzhkna"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  annotations   = []
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    placement = "bottom"
+                    type      = "list"
+                    visible   = true
+                  }
+                  thresholds = {
+                    startingColor = "Default"
+                    thresholds    = []
+                    visible       = false
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = ""
+                    unit      = "s"
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSSQSApproximateAgeOfOldestMessagesum_sum"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 250
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-20qfbodw"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        autoFrame = true
+                        dataVis = {
+                          config = {
+                            annotations   = []
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              placement = "bottom"
+                              type      = "list"
+                              visible   = true
+                            }
+                            thresholds = {
+                              startingColor = "Default"
+                              thresholds    = []
+                              visible       = false
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = ""
+                              unit      = "s"
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSSQSApproximateAgeOfOldestMessagesum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T23:51:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/ApproximateAgeOfOldestMessage.sum"
+                          nameWithPath        = "AWS/SQS/ApproximateAgeOfOldestMessage.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "max"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = "s"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSApproximateAgeOfOldestMessagesum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-prvqgx6u"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSSQSApproximateAgeOfOldestMessagesum_sum:max(m(\"AWS/SQS/ApproximateAgeOfOldestMessage.sum\"))",
+                "aggregate A_AWSSQSApproximateAgeOfOldestMessagesum_sum:sum(A_AWSSQSApproximateAgeOfOldestMessagesum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "k0as7qd4"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSSQSApproximateAgeOfOldestMessagesum_sum:max(m("AWS/SQS/ApproximateAgeOfOldestMessage.sum"))
+                    aggregate A_AWSSQSApproximateAgeOfOldestMessagesum_sum:sum(A_AWSSQSApproximateAgeOfOldestMessagesum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-bfrw9s43"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/SentMessageSizesum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 7
+          inputList     = []
+          isInternal    = false
+          label         = "Sent Message Size"
+          managers = [
+            {
+              id         = "6wktq8mh"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  annotations   = []
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    placement = "bottom"
+                    type      = "list"
+                    visible   = true
+                  }
+                  thresholds = {
+                    startingColor = "Default"
+                    thresholds    = []
+                    visible       = false
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    unit    = "bytes"
+                    visible = true
+                  }
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "avg"
+                    }
+                    timechart = {
+                      fn         = "avg"
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSSQSSentMessageSizesum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 250
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-2qsbsvfw"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        autoFrame = true
+                        dataVis = {
+                          config = {
+                            annotations   = []
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              placement = "bottom"
+                              type      = "list"
+                              visible   = true
+                            }
+                            thresholds = {
+                              startingColor = "Default"
+                              thresholds    = []
+                              visible       = false
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              unit    = "bytes"
+                              visible = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "avg"
+                              }
+                              timechart = {
+                                fn         = "avg"
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSSQSSentMessageSizesum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 5
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T23:39:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/SentMessageSize.sum"
+                          nameWithPath        = "AWS/SQS/SentMessageSize.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "120000000000"
+                          type                = "gauge"
+                          unit                = "By"
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSSentMessageSizesum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-cvevg0v6"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSSQSSentMessageSizesum_sum:sum(m(\"AWS/SQS/SentMessageSize.sum\"))",
+                "aggregate A_AWSSQSSentMessageSizesum_sum:sum(A_AWSSQSSentMessageSizesum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "wti86r69"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSSQSSentMessageSizesum_sum:sum(m("AWS/SQS/SentMessageSize.sum"))
+                    aggregate A_AWSSQSSentMessageSizesum_sum:sum(A_AWSSQSSentMessageSizesum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-txhxj2kv"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesDeletedsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 8
+          inputList     = []
+          isInternal    = false
+          label         = "Number of Messages Deleted"
+          managers = [
+            {
+              id         = "61j1a4fr"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  annotations   = []
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    placement = "bottom"
+                    type      = "list"
+                    visible   = true
+                  }
+                  thresholds = {
+                    startingColor = "Default"
+                    thresholds    = []
+                    visible       = false
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSSQSNumberOfMessagesDeletedsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 250
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-qjnqbwtn"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            annotations   = []
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              placement = "bottom"
+                              type      = "list"
+                              visible   = true
+                            }
+                            thresholds = {
+                              startingColor = "Default"
+                              thresholds    = []
+                              visible       = false
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSSQSNumberOfMessagesDeletedsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T21:57:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/NumberOfMessagesDeleted.sum"
+                          nameWithPath        = "AWS/SQS/NumberOfMessagesDeleted.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSNumberOfMessagesDeletedsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-carpvblw"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSSQSNumberOfMessagesDeletedsum_sum:sum(m(\"AWS/SQS/NumberOfMessagesDeleted.sum\"))",
+                "aggregate A_AWSSQSNumberOfMessagesDeletedsum_sum:sum(A_AWSSQSNumberOfMessagesDeletedsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "bnigqhdb"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSSQSNumberOfMessagesDeletedsum_sum:sum(m("AWS/SQS/NumberOfMessagesDeleted.sum"))
+                    aggregate A_AWSSQSNumberOfMessagesDeletedsum_sum:sum(A_AWSSQSNumberOfMessagesDeletedsum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-wwsekg1r"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/ApproximateNumberOfMessagesDelayedsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 9
+          inputList     = []
+          isInternal    = false
+          label         = "Approximate Number of Messages Delayed"
+          managers = [
+            {
+              id         = "9vq3onks"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  annotations   = []
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    placement = "bottom"
+                    type      = "list"
+                    visible   = true
+                  }
+                  thresholds = {
+                    startingColor = "Default"
+                    thresholds    = []
+                    visible       = false
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum"
+                  }
+                  topK = {
+                    k     = 100
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 250
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-um1yyloj"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            annotations   = []
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              placement = "bottom"
+                              type      = "list"
+                              visible   = true
+                            }
+                            thresholds = {
+                              startingColor = "Default"
+                              thresholds    = []
+                              visible       = false
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T23:51:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/ApproximateNumberOfMessagesDelayed.sum"
+                          nameWithPath        = "AWS/SQS/ApproximateNumberOfMessagesDelayed.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "avg"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-5xyjf0rq"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum:avg(m(\"AWS/SQS/ApproximateNumberOfMessagesDelayed.sum\"))",
+                "aggregate A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum:sum(A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "bb7uv1cc"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum:avg(m("AWS/SQS/ApproximateNumberOfMessagesDelayed.sum"))
+                    aggregate A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum:sum(A_AWSSQSApproximateNumberOfMessagesDelayedsum_sum), group_by(^Resource...)
+                EOT
+      },
+      {
+        id = "stage-dcwhlhvy"
+        input = [
+          {
+            datasetId   = local.metrics
+            datasetPath = null
+            inputName   = "AWS/SQS/NumberOfMessagesReceivedsum_from_AWS-Quickstart/Metrics"
+            inputRole   = "Data"
+            stageId     = null
+          },
+          {
+            datasetId   = null
+            datasetPath = null
+            inputName   = "AWS Asset Inventory"
+            inputRole   = "Data"
+            stageId     = null
+          },
+        ]
+        layout = {
+          cardLinks = []
+          dataLinks = []
+          dataTableViewState = {
+            cellValuePresentation       = []
+            columnOrderOverride         = []
+            columnVisibility            = []
+            columnWidths                = []
+            defaultColumnWidth          = 70
+            disableFixedLeftColumns     = false
+            minColumnWidth              = 60
+            preserveCellAndRowSelection = true
+            rowHeights                  = []
+            selection = {
+              cells                = {}
+              columnSelectSequence = []
+              columns              = {}
+              highlightState       = {}
+              rows                 = {}
+              selectionType        = "table"
+            }
+            tableWidth = 0
+            viewType   = "Auto"
+          }
+          disableOutput = false
+          index         = 10
+          inputList     = []
+          isInternal    = false
+          label         = "Number of Messages Received"
+          managers = [
+            {
+              id         = "0usikvlh"
+              isDisabled = false
+              type       = "Vis"
+              vis = {
+                config = {
+                  annotations   = []
+                  color         = "Default"
+                  hideGridLines = false
+                  legend = {
+                    placement = "bottom"
+                    type      = "list"
+                    visible   = true
+                  }
+                  thresholds = {
+                    startingColor = "Default"
+                    thresholds    = []
+                    visible       = false
+                  }
+                  type = "xy"
+                  xConfig = {
+                    visible = true
+                  }
+                  yConfig = {
+                    axisLabel = "Count"
+                    visible   = true
+                  }
+                }
+                source = {
+                  table = {
+                    statsBy = {
+                      fn = "count"
+                    }
+                    timechart = {
+                      fn         = "count"
+                      resolution = "AUTO"
+                    }
+                    transformType = "none"
+                    type          = "xy"
+                    x             = "valid_from"
+                    y             = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+                  }
+                  topK = {
+                    order = "Top"
+                    type  = "Auto"
+                  }
+                  type = "table"
+                }
+                type = "timeseries"
+              }
+            },
+          ]
+          queryPresentation = {
+            initialRollupFilter = {
+              mode = "Last"
+            }
+            limit          = 10000
+            linkify        = true
+            loadEverything = false
+            progressive    = true
+            resultKinds = [
+              "ResultKindSchema",
+              "ResultKindData",
+              "ResultKindColumnStats",
+              "ResultKindVolumeStats",
+              "ResultKindProgress",
+            ]
+            rollup = {}
+            sort = [
+              {
+                ascending  = false
+                columnName = "A_AWSSQSNumberOfMessagesSentsum_sum"
+              },
+            ]
+            wantBuckets = 250
+          }
+          renderType   = "TABLE"
+          serializable = true
+          steps = [
+            {
+              customName    = "Input"
+              customSummary = ""
+              id            = "step-8wh0cgyb"
+              index         = 0
+              isPinned      = false
+              opal          = []
+              type          = "InputStep"
+            },
+            {
+              action = {
+                params = {
+                  expressionList = {
+                    aggregationMode = "aggregate"
+                    expressions = [
+                      {
+                        dataVis = {
+                          config = {
+                            annotations   = []
+                            color         = "Default"
+                            hideGridLines = false
+                            legend = {
+                              placement = "bottom"
+                              type      = "list"
+                              visible   = true
+                            }
+                            thresholds = {
+                              startingColor = "Default"
+                              thresholds    = []
+                              visible       = false
+                            }
+                            type = "xy"
+                            xConfig = {
+                              visible = true
+                            }
+                            yConfig = {
+                              axisLabel = "Count"
+                              visible   = true
+                            }
+                          }
+                          source = {
+                            table = {
+                              statsBy = {
+                                fn = "count"
+                              }
+                              timechart = {
+                                fn         = "count"
+                                resolution = "AUTO"
+                              }
+                              transformType = "none"
+                              type          = "xy"
+                              x             = "valid_from"
+                              y             = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+                            }
+                            topK = {
+                              order = "Top"
+                              type  = "Auto"
+                            }
+                            type = "table"
+                          }
+                          type = "timeseries"
+                        }
+                        expressionIdentifier = "A"
+                        filterActions = [
+                          {
+                            params = {
+                              checkedKeys          = []
+                              columnId             = "dimensions"
+                              columnType           = "object"
+                              differentPathsUseAnd = true
+                              expandedKeys         = []
+                              filterVerb           = "filter"
+                              paths = {
+                                QueueName = false
+                              }
+                              valuesForPath = {}
+                            }
+                            summary = null
+                            type    = "FilterJSONKey"
+                          },
+                          {
+                            params = {
+                              columnId    = "Resource"
+                              columnType  = "link"
+                              datasetKind = "Event"
+                              fk = {
+                                dstFields = [
+                                  "AccountID",
+                                  "Region",
+                                  "Service",
+                                  "ID",
+                                ]
+                                label = "Resource"
+                                srcFields = [
+                                  "account_id",
+                                  "region",
+                                  "service",
+                                  "resourceId",
+                                ]
+                                targetDataset = local.aws_asset_inventory
+                                type          = "linked"
+                              }
+                              parameterFilters = [
+                                {
+                                  parameterId = "input-parameter-oqnf8rxx"
+                                },
+                              ]
+                            }
+                            summary = null
+                            type    = "FilterParameter"
+                          },
+                        ]
+                        frameDuration = {
+                          num  = 1
+                          unit = "minute"
+                        }
+                        groupBy = [
+                          {
+                            label = "Resource"
+                            srcFields = [
+                              "account_id",
+                              "region",
+                              "service",
+                              "resourceId",
+                            ]
+                          },
+                        ]
+                        id             = "metricExpression-l7bqgdn0"
+                        invalidGroupBy = []
+                        lookupActions  = []
+                        metric = {
+                          aggregate   = "sum"
+                          datasetId   = local.metrics
+                          description = "Auto Detected Metric"
+                          heuristics = {
+                            lastReported = "2024-11-18T19:23:00Z"
+                            tags = [
+                              {
+                                column = "resourceId"
+                                path   = ""
+                              },
+                              {
+                                column = "account_id"
+                                path   = ""
+                              },
+                              {
+                                column = "region"
+                                path   = ""
+                              },
+                              {
+                                column = "service"
+                                path   = ""
+                              },
+                              {
+                                column = "dimensions"
+                                path   = "QueueName"
+                              },
+                            ]
+                            validLinkLabels = [
+                              "Resource",
+                            ]
+                          }
+                          name                = "AWS/SQS/NumberOfMessagesReceived.sum"
+                          nameWithPath        = "AWS/SQS/NumberOfMessagesReceived.sum (AWS-Quickstart/Metrics)"
+                          rollup              = "sum"
+                          state               = "Active"
+                          suggestedBucketSize = "60000000000"
+                          type                = "gauge"
+                          unit                = ""
+                          userDefined         = false
+                        }
+                        noDataVisBindingUpdate = false
+                        showAlignment          = true
+                        showResolution         = false
+                        summaryMode            = "over-time"
+                        type                   = "metricExpression"
+                        valueColumnId          = "A_AWSSQSNumberOfMessagesReceivedsum_sum"
+                        viewTab                = "visualize"
+                      },
+                    ]
+                    multiExpression = {
+                      expressionIdentifier   = "A"
+                      filterActions          = []
+                      id                     = "multiExpression-bnvdwqzy"
+                      lookupActions          = []
+                      noDataVisBindingUpdate = false
+                      type                   = "multiExpression"
+                      viewTab                = "visualize"
+                    }
+                    selectedExpressionIds = [
+                      "metricExpression-l7bqgdn0",
+                    ]
+                    shouldLimitPatterns = true
+                  }
+                }
+                summary = null
+                type    = "ExpressionBuilder"
+              }
+              customSummary = "Expression Builder"
+              id            = "step-ull7vav1"
+              index         = 1
+              isPinned      = false
+              opal = [
+                "filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json(\"null\")))",
+                "exists account_id = @\"AWS Asset Inventory\".AccountID, region = @\"AWS Asset Inventory\".Region, service = @\"AWS Asset Inventory\".Service, resourceId = @\"AWS Asset Inventory\".ID",
+                "align A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(m(\"AWS/SQS/NumberOfMessagesReceived.sum\"))",
+                "aggregate A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(A_AWSSQSNumberOfMessagesReceivedsum_sum), group_by(^Resource...)",
+              ]
+              type = "unknown"
+            },
+          ]
+          type = "table"
+          viewModel = {
+            builderOpalTab       = "Builder"
+            inspectRailCollapsed = true
+            inspectRailPinned    = false
+            inspectRailWidth     = 640
+            railCollapseState = {
+              inputsOutputs = false
+              minimap       = false
+              note          = true
+              script        = true
+            }
+            showTimeRuler = true
+            stageTab      = "vis"
+            thumbnailId   = "kiffafbn"
+          }
+        }
+        params   = null
+        pipeline = <<-EOT
+                    filter (not (is_null(dimensions.QueueName) or dimensions.QueueName = parse_json("null")))
+                    exists account_id = @"AWS Asset Inventory".AccountID, region = @"AWS Asset Inventory".Region, service = @"AWS Asset Inventory".Service, resourceId = @"AWS Asset Inventory".ID
+                    align A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(m("AWS/SQS/NumberOfMessagesReceived.sum"))
+                    aggregate A_AWSSQSNumberOfMessagesReceivedsum_sum:sum(A_AWSSQSNumberOfMessagesReceivedsum_sum), group_by(^Resource...)
+                EOT
+      },
+    ]
+  )
+  workspace = local.workspace
+}
+

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,17 @@
 locals {
-  workspace           = var.workspace.oid
-  datastream          = var.datastream.dataset
-  home_dashboard_name = format(var.name_format, "Home")
-  resources           = observe_dataset.resources.id
-  logs                = observe_dataset.logs.id
-  metrics             = observe_dataset.metrics.id
+  workspace             = var.workspace.oid
+  datastream            = var.datastream.dataset
+  home_dashboard_name   = format(var.name_format, "Home")
+  ec2_dashboard_name    = format(var.name_format, "EC2 Instances")
+  lambda_dashboard_name = format(var.name_format, "Lambda Instances")
+  rds_dashboard_name    = format(var.name_format, "RDS Instances")
+  sqs_dashboard_name    = format(var.name_format, "SQS Services")
+
+  resources = observe_dataset.resources.id
+  logs      = observe_dataset.logs.id
+  metrics   = observe_dataset.metrics.id
+
+  #Instance dashboard locals are referred by this name 
+  aws_asset_inventory = observe_dataset.resources.id
 }
+


### PR DESCRIPTION
## What does this PR do?

Adds quickstart instance dashboards for:

- EC2
- Lambda
- RDS
- SQS 

## Testing

- Pre-release: Tested in staging
- Terraform with data cross-check with AWS Eng: Tested in o2 


Links to Dashboard in o2 for terraformed:
https://102.observe-o2.com/workspace/41000009/dashboards?search=nikhil-aws