### PR TITLE
fix: increase max_time_diff to 4h for AWS Config

### DIFF
--- a/resources.tf
+++ b/resources.tf
@@ -24,7 +24,7 @@ resource "observe_dataset" "resources" {
 
         filter not is_null(recordType)
         make_col fileCreationTime:parse_timestamp(fileCreationTime, "YYYYMMDDTHH24MISSZ")
-        set_valid_from options(max_time_diff:30m), fileCreationTime
+        set_valid_from options(max_time_diff:4h), fileCreationTime
 
         make_col
           timestamp:fileCreationTime,
@@ -95,7 +95,7 @@ resource "observe_dataset" "resources" {
 
         filter not is_null(recordType)
         make_col fileCreationTime:parse_timestamp(fileCreationTime, "YYYYMMDDTHH24MISSZ")
-        set_valid_from options(max_time_diff:30m), fileCreationTime
+        set_valid_from options(max_time_diff:4h), fileCreationTime
 
         make_col
           timestamp:fileCreationTime,


### PR DESCRIPTION
While testing the AWS integration (aws-sam-apps), setting the AWS Config outside of the aws-sam-apps could accumulate resources data with `max_time_diff:4h`. 

<img width="1506" alt="Screenshot 2025-01-13 at 10 07 58 PM" src="https://github.com/user-attachments/assets/e8d5151c-3e4d-4a14-8fd0-72950adc2fe8" />
<img width="1315" alt="Screenshot 2025-01-13 at 10 08 14 PM" src="https://github.com/user-attachments/assets/448319a7-4411-4255-a78b-d412b081cbc0" />
