### PR TITLE
fix: Changes to update the default template for filedrops

### DIFF
--- a/sources/filedrop/README.md
+++ b/sources/filedrop/README.md
@@ -2,6 +2,6 @@ This source will collect logs, metrics and resource data from a target AWS accou
 
 Upon install, this source will provide install instructions using both CloudFormation and Terraform.
 
-More detailed documentation on the CloudFormation stack and collection architecture is available in the [aws-sam-apps repository](https://github.com/observeinc/aws-sam-apps/blob/main/docs/collection.md).
+More detailed documentation on the CloudFormation stack and collection architecture is available in the [aws-sam-apps repository](https://github.com/observeinc/aws-sam-apps/blob/main/docs/stack.md). 
 
-Documentation for the `observeinc/collection/aws` Terraform module is available in the [HashiCorp registry](https://registry.terraform.io/modules/observeinc/collection/aws/latest/submodules/collection).
+Documentation for the `observeinc/collection/aws` Terraform module is available in the [HashiCorp registry](https://registry.terraform.io/modules/observeinc/collection/aws/latest).

--- a/sources/filedrop/main.tf
+++ b/sources/filedrop/main.tf
@@ -10,20 +10,6 @@ locals {
     uri = "https://${nonsensitive(observe_datastream_token.this[0].secret)}@${trim(data.observe_ingest_info.this[0].collect_url, "https://")}/v1/http"
   }
 
-  # the frontend gets the keys, which are the cluster names from 
-  # ops/kubernetes/clusters/{CLUSTER_NAME}/vars/shared-domain.env
-  cluster_region_map = {
-    eng         = "us-west-2"
-    o2          = "us-west-2"
-    prod        = "us-west-2"
-    sandbox     = "us-west-2"
-    staging     = "us-west-2"
-    prod-cap1-2 = "us-west-2"
-    prod-ap-1   = "ap-northeast-1"
-    prod-cap1   = "us-east-1"
-    prod-eu-1   = "eu-central-1"
-    prod-cba-1  = "ap-southeast-2"
-  }
 
   post_install_vars = {
     quick_create_link              = local.quick_create_link
@@ -56,6 +42,8 @@ locals {
   ) : trimspace(line)])
 }
 
+data "observe_cloud_info" "this" {}
+
 resource "observe_filedrop" "aws_filedrop" {
   count      = local.enable_filedrop ? 1 : 0
   workspace  = var.workspace.oid
@@ -66,7 +54,7 @@ resource "observe_filedrop" "aws_filedrop" {
   config {
     provider {
       aws {
-        region   = lookup(local.cluster_region_map, var.observe_cluster, "us-west-2")
+        region   = data.observe_cloud_info.this.region
         role_arn = local.aws_role_arn
       }
     }

--- a/sources/filedrop/post_install.tftpl
+++ b/sources/filedrop/post_install.tftpl
@@ -45,8 +45,12 @@ module "observe" {
 %{ endif ~}
   }
 
+#  You may configure the forwarder if needed
+#   forwarder = {
+
   ## Grant forwarder access to read from pre-existing S3 buckets
-  # source_bucket_names = ["*"]
+  # source_bucket_names = ["bucket-1","bucket-2"]
+# }
 
 %{ if !enable_config }  /*%{ endif ~}
   # enable AWS Config collection

--- a/sources/filedrop/variables.tf
+++ b/sources/filedrop/variables.tf
@@ -12,13 +12,6 @@ variable "aws_region" {
     EOF
 }
 
-variable "observe_cluster" {
-  type        = string
-  description = <<-EOF
-      The cluster where Observe is installed.
-    EOF
-}
-
 variable "enable_config" {
   type        = bool
   description = <<-EOF

--- a/sources/s3forwarder/main.tf
+++ b/sources/s3forwarder/main.tf
@@ -6,21 +6,6 @@ locals {
   destination      = observe_filedrop.aws_filedrop.endpoint[0].s3[0]
   access_point_arn = observe_filedrop.aws_filedrop.endpoint[0].s3[0].arn
 
-  # the frontend gets the keys, which are the cluster names from 
-  # ops/kubernetes/clusters/{CLUSTER_NAME}/vars/shared-domain.env
-  cluster_region_map = {
-    eng         = "us-west-2"
-    o2          = "us-west-2"
-    prod        = "us-west-2"
-    sandbox     = "us-west-2"
-    staging     = "us-west-2"
-    prod-cap1-2 = "us-west-2"
-    prod-ap-1   = "ap-northeast-1"
-    prod-cap1   = "us-east-1"
-    prod-eu-1   = "eu-central-1"
-    prod-cba-1  = "ap-southeast-2"
-  }
-
   post_install_vars = {
     quick_create_link         = local.quick_create_link
     name                      = local.name
@@ -34,7 +19,7 @@ locals {
   cloudformation_parameters = {
     DataAccessPointArn = local.access_point_arn
     DestinationUri     = "s3://${local.destination.bucket}/${local.destination.prefix}"
-    SourceBucketNames  = join("", var.source_bucket_names)
+    SourceBucketNames  = join(",", var.source_bucket_names)
   }
 
   quick_create_link = join("", [for line in split("\n", <<-EOF
@@ -48,6 +33,8 @@ locals {
   ) : trimspace(line)])
 }
 
+data "observe_cloud_info" "this" {}
+
 resource "observe_filedrop" "aws_filedrop" {
   workspace  = var.workspace.oid
   datastream = var.datastream.oid
@@ -57,7 +44,7 @@ resource "observe_filedrop" "aws_filedrop" {
   config {
     provider {
       aws {
-        region   = lookup(local.cluster_region_map, var.observe_cluster, "us-west-2")
+        region   = data.observe_cloud_info.this.region
         role_arn = local.aws_role_arn
       }
     }

--- a/sources/s3forwarder/variables.tf
+++ b/sources/s3forwarder/variables.tf
@@ -12,13 +12,6 @@ variable "aws_region" {
     EOF
 }
 
-variable "observe_cluster" {
-  type        = string
-  description = <<-EOF
-      The cluster where Observe is installed.
-    EOF
-}
-
 variable "source_bucket_names" {
   type        = list(string)
   description = <<-EOF


### PR DESCRIPTION
filedrops push needed to surround with forwarder for source_bucket_names

## What does this PR do?

This fixes a commented out section for **source_bucket_names**.  If uncommented this will break the terraform process. There are also updates to some of the links within the documentation that were broken.

## Testing

Ran terraform successfully with the included code and a bucket name that exists within my AWS account.
