### PR TITLE
fix(metrics): specify correct units for percent

### DIFF
--- a/metrics.tf
+++ b/metrics.tf
@@ -137,7 +137,7 @@ resource "observe_dataset" "metrics" {
             unit = "Megabits", "mb",
             unit = "Gigabits", "gb",
             unit = "Terabits", "tb",
-            unit = "Percent", "percent(0-100)",
+            unit = "Percent", "percent (0-100)",
             unit = "Count", string_null(),
             unit = "Bytes/Second", "B/s",
             unit = "Kilobytes/Second", "kB",


### PR DESCRIPTION
## What does this PR do?

Fixes missing space in percent units on metrics