### PR TITLE
fix: Update networkELB to include AWS namespace - OBSSD-1396

### DIFF
--- a/metrics.tf
+++ b/metrics.tf
@@ -67,7 +67,7 @@ resource "observe_dataset" "metrics" {
           value:float64(_c_ob_value),
           unit:if(_c_ob_path="count", string_null(), unit),
           service:case(
-            namespace="NetworkELB", "ElasticLoadBalancingV2",
+            namespace="AWS/NetworkELB", "ElasticLoadBalancingV2",
             namespace="AWS/EBS", "EC2",
             namespace="AWS/Firehose", "KinesisFirehose",
             namespace="AWS/ApplicationELB", "ElasticLoadBalancingV2",
@@ -116,7 +116,7 @@ resource "observe_dataset" "metrics" {
           namespace="AWS/CloudWatch/MetricStreams" and path_exists(dimensions, "MetricStreamName"), string(dimensions["MetricStreamName"]),
           namespace="AWS/DynamoDB" and path_exists(dimensions, "TableName"), string(dimensions["TableName"]),
           service="SageMaker" and path_exists(dimensions, "EndpointName"), string(dimensions["EndpointName"]),
-          namespace="NetworkELB" and path_exists(dimensions, "LoadBalancer"), concat_strings("arn:aws:elasticloadbalancing:", region, ":", account_id, ":loadbalancer/", string(dimensions["LoadBalancer"])),
+          namespace="AWS/NetworkELB" and path_exists(dimensions, "LoadBalancer"), concat_strings("arn:aws:elasticloadbalancing:", region, ":", account_id, ":loadbalancer/", string(dimensions["LoadBalancer"])),
           true, resourceId
         )
 


### PR DESCRIPTION
## What does this PR do?

Updates the `networkELB` integration to explicitly include the AWS namespace. Without this addition, certain metrics and resources were not being properly identified.

## Motivation

This fix ensures more accurate metric collection and alignment with AWS conventions, improving reliability for customers using networkELB.

## Testing

Ensured metrics are correctly captured and associated with their AWS service context.
