### PR TITLE
fix: add -filedrop suffix to the default filedrop AWS role name to match the SAM app default

### DIFF
--- a/sources/filedrop/main.tf
+++ b/sources/filedrop/main.tf
@@ -3,7 +3,7 @@ locals {
 
   enable_filedrop = var.enable_filedrop
 
-  aws_role_arn = local.enable_filedrop ? "arn:aws:iam::${var.aws_account_id}:role/${local.name}" : ""
+  aws_role_arn = local.enable_filedrop ? "arn:aws:iam::${var.aws_account_id}:role/${local.name}-filedrop" : ""
   template_url = "https://observeinc-${var.aws_region}.s3.amazonaws.com/aws-sam-apps/${var.release_version}/stack.yaml"
 
   destination = local.enable_filedrop ? observe_filedrop.aws_filedrop[0].endpoint[0].s3[0] : {

--- a/sources/s3forwarder/main.tf
+++ b/sources/s3forwarder/main.tf
@@ -1,7 +1,7 @@
 locals {
   name = replace(var.name, "{region}", var.aws_region)
 
-  aws_role_arn     = "arn:aws:iam::${var.aws_account_id}:role/${local.name}"
+  aws_role_arn     = "arn:aws:iam::${var.aws_account_id}:role/${local.name}-filedrop"
   template_url     = "https://observeinc-${var.aws_region}.s3.amazonaws.com/aws-sam-apps/${var.release_version}/forwarder.yaml"
   destination      = observe_filedrop.aws_filedrop.endpoint[0].s3[0]
   access_point_arn = observe_filedrop.aws_filedrop.endpoint[0].s3[0].arn

--- a/tftests/default/main.tf
+++ b/tftests/default/main.tf
@@ -4,14 +4,30 @@ data "observe_workspace" "default" {
   name = "Default"
 }
 
-data "observe_datastream" "default" {
+# Avoid System datastream: filedrop/tokens are often not permitted there.
+resource "observe_datastream" "test" {
   workspace = data.observe_workspace.default.oid
-  name      = "System"
+  name      = "test-${random_pet.test.id}"
 }
 
 module "default" {
   source      = "../.."
   workspace   = data.observe_workspace.default
   name_format = "test_${random_pet.test.id}/%s"
-  datastream  = data.observe_datastream.default
+  datastream = {
+    dataset = observe_datastream.test.dataset
+  }
+}
+
+module "filedrop" {
+  source = "../../sources/filedrop"
+
+  workspace = { oid = data.observe_workspace.default.oid }
+  datastream = {
+    oid = observe_datastream.test.oid
+  }
+
+  aws_account_id = "123456789012"
+  aws_region     = "us-west-2"
+  name           = "test-${random_pet.test.id}-observe-collection-{region}"
 }

--- a/tftests/default/versions.tf
+++ b/tftests/default/versions.tf
@@ -5,9 +5,9 @@ terraform {
       version = ">= 3"
     }
     observe = {
-      source  = "terraform.observeinc.com/observeinc/observe"
-      version = "~> 0.13"
+      source  = "observeinc/observe"
+      version = "~> 0.14"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.1.0"
 }


### PR DESCRIPTION
## What does this PR do?

Add the `-filedrop` suffix to the default filedrop AWS role name.

## Motivation

This matches the behavior of the SAM app and our connections portal.

## Testing

I updated the default test and verified locally that the suffix is now added to the role name by default.